### PR TITLE
GCPData dependencies updated. Dependencies found with Snakefood utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test
 *.pyc
 *.idea
 *.iml
+*.egg-info
 
 # For building the server incrementally from an IDE like Eclipse it can be useful to create
 # the two symlinks below to point to sources/server/src/shared, but we don't want them

--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -94,8 +94,8 @@ ADD docs/ /datalab/docs
 ADD content/ /datalab
 
 # Install build artifacts
-RUN cd /datalab/lib/GCPData-0.1.0 && python setup.py install && \
-    cd /datalab/lib/GCPDataLab-0.1.0 && python setup.py install && \
+RUN cd /datalab/lib/GCPData-0.1.0 && pip install . && \
+    cd /datalab/lib/GCPDataLab-0.1.0 && pip install . && \
     cd /datalab/web && /tools/node/bin/npm install && \
     cd /
 

--- a/sources/lib/api/build.sh
+++ b/sources/lib/api/build.sh
@@ -15,4 +15,3 @@ mkdir -p $BUILD_DIR
 
 # Build a source distribution package
 python setup.py sdist --dist-dir=$BUILD_DIR
-mv MANIFEST $BUILD_DIR/GCPData.manifest

--- a/sources/lib/api/gcp/_util/__init__.py
+++ b/sources/lib/api/gcp/_util/__init__.py
@@ -25,4 +25,5 @@ from ._lru_cache import LRUCache
 from ._metadata import MetadataService
 from ._sql import Sql
 from ._utils import print_exception_with_last_stack
+from ._context import Context
 

--- a/sources/lib/api/gcp/_util/_context.py
+++ b/sources/lib/api/gcp/_util/_context.py
@@ -14,8 +14,8 @@
 
 """Implements Context functionality."""
 
-from ._util import MetadataCredentials
-from ._util import MetadataService
+from ._credentials import MetadataCredentials
+from ._metadata import MetadataService
 
 
 class Context(object):

--- a/sources/lib/api/gcp/bigquery/__init__.py
+++ b/sources/lib/api/gcp/bigquery/__init__.py
@@ -14,7 +14,6 @@
 
 """Google Cloud Platform library - BigQuery Functionality."""
 
-import gcp as _gcp
 import gcp._util as _util
 from ._api import Api as _Api
 from ._dataset import DataSet as _DataSet
@@ -41,7 +40,7 @@ def _create_api(context):
     An Api object to make BigQuery HTTP API requests.
   """
   if context is None:
-    context = _gcp.Context.default()
+    context = _util.Context.default()
   return _Api(context.credentials, context.project_id)
 
 

--- a/sources/lib/api/gcp/storage/__init__.py
+++ b/sources/lib/api/gcp/storage/__init__.py
@@ -30,7 +30,7 @@ def _create_api(context):
     An Api object to make Storage HTTP API requests.
   """
   if context is None:
-    context = _gcp.Context.default()
+    context = _gcp._util.Context.default()
   return _Api(context.credentials, context.project_id)
 
 

--- a/sources/lib/api/setup.py
+++ b/sources/lib/api/setup.py
@@ -22,24 +22,24 @@ from setuptools import setup
 # Also, figure out publishing, so this works with pip install, and specifying
 # dependencies, so they can be accounted for during installation.
 # Known depdenencies:
+# - futures
 # - httplib2
 # - oauth2client
 # - pandas
+# - py-dateutil
 
 setup(
     name='GCPData',
     version='0.1.0',
-    packages=['gcp',
-              'gcp._util',
+    namespace_packages=['gcp'],
+    packages=['gcp._util',
               'gcp.bigquery',
               'gcp.storage',
              ],
     description='Google Cloud APIs for data analysis scenarios.',
-    install_requires=['futures',
-              'httplib2',
-              'IPython',
-              'oauth2client',
-              'pandas',
-              'requests'
-             ]
+    install_requires=['futures==3.0.3',
+                      'httplib2==0.9.1',
+                      'oauth2client==1.4.12',
+                      'pandas==0.16.2',
+                      'py-dateutil==2.2']
 )

--- a/sources/lib/datalab/build.sh
+++ b/sources/lib/datalab/build.sh
@@ -15,4 +15,3 @@ mkdir -p $BUILD_DIR
 
 # Build a source distribution package
 python setup.py sdist --dist-dir=$BUILD_DIR
-mv MANIFEST $BUILD_DIR/GCPDataLab.manifest

--- a/sources/lib/datalab/gcp/__init__.py
+++ b/sources/lib/datalab/gcp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Google Cloud Platform library - General Functionality."""

--- a/sources/lib/datalab/gcp/ipython/_notebooks.py
+++ b/sources/lib/datalab/gcp/ipython/_notebooks.py
@@ -510,7 +510,7 @@ class DataLabNotebookManager(CompositeNotebookManager):
     # as we can make it). Some caveats:
     # - The name cannot contain 'google'
     # - Project ids maybe domain-qualified, eg. foo.com:bar
-    project_id = _gcp.Context.default().project_id
+    project_id = _gcp._util.Context.default().project_id
     project_id = project_id.replace('google.com', 'gcom').replace(':', '-').replace('.', '-')
     bucket_name = project_id + '-datalab'
 

--- a/sources/lib/datalab/setup.py
+++ b/sources/lib/datalab/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils.core import setup
+from setuptools import setup
 
 # TODO(nikhilko):
 # Fill in various other bits that can/should be specified once we have them.
@@ -21,9 +21,13 @@ from distutils.core import setup
 setup(
     name='GCPDataLab',
     version='0.1.0',
+    namespace_packages=['gcp'],
     packages=['gcp.datalab', 'gcp.ipython'],
     description='Google Cloud DataLab',
-    requires=['IPython',
-              'GCPData'
-             ]
+    install_requires=['httplib2==0.9.1',
+                      'pandas==0.16.2',
+                      'requests==2.4.3',
+                      'ipython==2.4.1',
+                      'GCPData'
+                     ]
 )


### PR DESCRIPTION
This time actually addresses comments stated in #480. 
- Removed unnecessary dependencies of the installer (such as a dependency on IPython).
- Switched from distutils to setuptools as suggested in the [Python Packaging Guide](https://packaging.python.org/en/latest/current.html):

    > Use setuptools to define projects and create Source Distributions.

- Changed Dockerfile.in to use pip instead of python setup.py install
- Changed layout of packages to use a shared namespace package called gcp, and thereby each library extends the namespace, with GCPDataLab requiring GCPData. More information here: [link](https://pythonhosted.org/setuptools/setuptools.html#namespace-packages)