### PR TITLE
Fix a bug in the parsing of records with repeated scalar fields.

### DIFF
--- a/sources/lib/api/gcp/bigquery/_parser.py
+++ b/sources/lib/api/gcp/bigquery/_parser.py
@@ -68,7 +68,7 @@ class Parser(object):
         else:
           row[name] = Parser.parse_row(sub_schema, val)
       elif repeated:
-        row[name] = [parse_value(data_type, v) for v in val]
+        row[name] = [parse_value(data_type, v['v']) for v in val]
       else:
         row[name] = parse_value(data_type, val)
 

--- a/sources/lib/api/tests/bq_parser_tests.py
+++ b/sources/lib/api/tests/bq_parser_tests.py
@@ -16,6 +16,14 @@ import gcp.bigquery as bq
 
 class TestCases(unittest.TestCase):
 
+  def test_repeating_data(self):
+    schema = [{'name': 'counts', 'type': 'INTEGER', 'mode': 'REPEATED'}]
+    data = {'f': [{'v': [{'v': 0}, {'v': 1}, {'v': 2}]}]}
+    parsed = {'counts': [0, 1, 2]}
+    result = bq._parser.Parser.parse_row(schema, data)
+    self.assertEqual(parsed, result)
+
+
   def test_non_nested_data(self):
 
     data = {u'f': [{u'v': u'1969'},


### PR DESCRIPTION
We were expecting a list of values, but we get a list of dictionaries with each containing a single value keyed on 'v'.
