### PR TITLE
Fix a bug in saving notebooks.

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -265,7 +265,7 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     // This is a hack to disable timestamp check due to a Workspace-sync bug.
     var originalSave = notebook.prototype.save_notebook;
     notebook.prototype.save_notebook = function() {
-      originalSave.apply(this, /* check_lastmodified */ [ false ]);
+      return originalSave.apply(this, /* check_lastmodified */ [ false ]);
     }
   });
 


### PR DESCRIPTION
The original save was replaced by a new version to work around an issue
with workspace sync. However, the new version does not return the wrapped
return value, so places where we chain off that future (e.g. with calls to
then()) got broken. This means, for example, that 'Convert to HTML' will
fail if the notebook has unsaved changes.