### PR TITLE
Jobs should run as my current project, unless specified

### DIFF
--- a/sources/lib/api/gcp/bigquery/_api.py
+++ b/sources/lib/api/gcp/bigquery/_api.py
@@ -139,10 +139,7 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    if table_name:
-      url = Api._ENDPOINT + (Api._JOBS_PATH % (table_name.project_id, ''))
-    else:
-      url = Api._ENDPOINT + (Api._JOBS_PATH % (self._project_id, ''))
+    url = Api._ENDPOINT + (Api._JOBS_PATH % (self._project_id, ''))
     data = {
       'kind': 'bigquery#job',
       'configuration': {


### PR DESCRIPTION
Jobs should run as my current project, unless specified.

My datalab project is the one that should be used for running the queries, even if I have a destination table in a different project.

The destination table project needs to give me permissions to write into their dataset, but the query should be charged to the authenticated project.

Note that project_id is parsed a second time later in this method - there are 2 project ids, and they should be allowed to be independent.