### PR TITLE
Support for querying from external tables.

### DIFF
--- a/sources/lib/api/gcp/bigquery/__init__.py
+++ b/sources/lib/api/gcp/bigquery/__init__.py
@@ -12,7 +12,9 @@
 
 """Google Cloud Platform library - BigQuery Functionality."""
 
+from _csv_options import CSVOptions
 from _dataset import DataSet, DataSets
+from _federated_table import FederatedTable
 from _job import Job
 from _query import Query
 from _query_job import QueryJob

--- a/sources/lib/api/gcp/bigquery/_api.py
+++ b/sources/lib/api/gcp/bigquery/_api.py
@@ -115,9 +115,9 @@ class Api(object):
     }
     return gcp._util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False,
-                        overwrite=False, dry_run=False, use_cache=True, batch=True,
-                        allow_large_results=False):
+  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False, overwrite=False,
+                        dry_run=False, use_cache=True, batch=True, allow_large_results=False,
+                        table_definitions=None):
     """Issues a request to insert a query job.
 
     Args:
@@ -136,6 +136,8 @@ class Api(object):
           priority, more expensive).
       allow_large_results: whether to allow large results (slower with some restrictions but
           can handle big jobs).
+      table_definitions: a list of JSON external table definitions for any external tables
+          referenced in the query.
     Returns:
       A parsed result object.
     Raises:
@@ -165,6 +167,9 @@ class Api(object):
       resources.extend([{'resourceUri': uri} for uri in imports])
 
     query_config['userDefinedFunctionResources'] = resources
+
+    if table_definitions:
+      query_config['tableDefinitions'] = table_definitions
 
     if table_name:
       query_config['destinationTable'] = {

--- a/sources/lib/api/gcp/bigquery/_csv_options.py
+++ b/sources/lib/api/gcp/bigquery/_csv_options.py
@@ -1,0 +1,81 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Implements CSV options for External Tables and Table loads from GCS."""
+
+
+class CSVOptions(object):
+
+  def __init__(self, delimiter=',', skip_leading_rows=0, encoding='utf-8', quote='"',
+               allow_quoted_newlines=False, allow_jagged_rows=False):
+
+    """ Initialize an instance of CSV options.
+
+    Args:
+      delimiter: The separator for fields in a CSV file. BigQuery converts the string to
+          ISO-8859-1 encoding, and then uses the first byte of the encoded string to split the data
+          as raw binary (default ',').
+      skip_leading_rows: A number of rows at the top of a CSV file to skip (default 0).
+      encoding: The character encoding of the data, either 'utf-8' (the default) or 'iso-8859-1'.
+      quote: The value used to quote data sections in a CSV file; default '"'. If your data does
+          not contain quoted sections, set the property value to an empty string. If your data
+          contains quoted newline characters, you must also enable allow_quoted_newlines.
+      allow_quoted_newlines: If True, allow quoted data sections in CSV files that contain newline
+          characters (default False).
+      allow_jagged_rows: If True, accept rows in CSV files that are missing trailing optional
+          columns; the missing values are treated as nulls (default False).
+    """
+    encoding_upper = encoding.upper()
+    if encoding_upper != 'UTF-8' and encoding_upper != 'ISO-8859-1':
+      raise Exception("Invalid source encoding %s" % encoding)
+
+    self._delimiter = delimiter
+    self._skip_leading_rows = skip_leading_rows
+    self._encoding = encoding
+    self._quote = quote
+    self._allow_quoted_newlines = allow_quoted_newlines
+    self._allow_jagged_rows = allow_jagged_rows
+
+  @property
+  def delimiter(self):
+    return self._delimiter
+
+  @property
+  def skip_leading_rows(self):
+    return self._skip_leading_rows
+
+  @property
+  def encoding(self):
+    return self._encoding
+
+  @property
+  def quote(self):
+      return self._quote
+
+  @property
+  def allow_quoted_newlines(self):
+    return self._allow_quoted_newlines
+
+  @property
+  def allow_jagged_rows(self):
+    return self._allow_jagged_rows
+
+  def _to_query_json(self):
+    """ Return the options as a dictionary to be used as JSON in a query job. """
+    return {
+      'quote': self._quote,
+      'fieldDelimiter': self._delimiter,
+      'encoding': self._encoding.upper(),
+      'skipLeadingRows': self._skip_leading_rows,
+      'allowQuotedNewlines': self._allow_quoted_newlines,
+      'allowJaggedRows': self._allow_jagged_rows
+    }

--- a/sources/lib/api/gcp/bigquery/_federated_table.py
+++ b/sources/lib/api/gcp/bigquery/_federated_table.py
@@ -1,0 +1,98 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Implemenents External Table functionality."""
+
+import gcp
+import _api
+import _csv_options
+import _job
+
+
+class FederatedTable(object):
+
+  @staticmethod
+  def from_storage(source, source_format='csv', csv_options=None, ignore_unknown_values=False,
+                   max_bad_records=0, compressed=False, schema=None):
+
+    """ Create an external table for a GCS object.
+
+    Args:
+      source: the URL of the source objects(s). Can include a wildcard '*' at the end of the item
+         name. Can be a single source or a list.
+      source_format: the format of the data, 'csv' or 'json'; default 'csv'.
+      csv_options: For CSV files, the options such as quote character and delimiter.
+      ignore_unknown_values: If True, accept rows that contain values that do not match the schema;
+          the unknown values are ignored (default False).
+      max_bad_records The maximum number of bad records that are allowed (and ignored) before
+          returning an 'invalid' error in the Job result (default 0).
+      compressed: whether the data is GZ compressed or not (default False). Note that compressed
+          data can be used as a federated table but cannot be loaded into a BQ Table.
+      schema: the schema of the data. This is required for this table to be used as a federated
+          table or to be loaded using a Table object that itself has no schema (default None).
+
+  """
+    result = FederatedTable()
+    # Do some sanity checking and concert some params from friendly form to form used by BQ.
+    if source_format == 'csv':
+      result._bq_source_format = 'CSV'
+      if csv_options is None:
+        csv_options = _csv_options.CSVOptions()  # use defaults
+    elif source_format == 'json':
+      if csv_options:
+        raise Exception('CSV options are not support for JSON tables')
+      result._bq_source_format = 'NEWLINE_DELIMITED_JSON'
+    else:
+      raise Exception("Invalid source format %s" % source_format)
+
+    result._source = source if isinstance(source, list) else [source]
+    result._source_format = source_format
+    result._csv_options = csv_options
+    result._ignore_unknown_values = ignore_unknown_values
+    result._max_bad_records = max_bad_records
+    result._compressed = compressed
+    result._schema = schema
+    return result
+
+  def __init__(self):
+
+    """ Create an external table reference. Do not call this directly; use factory method(s). """
+    # Do some sanity checking and concert some params from friendly form to form used by BQ.
+    self._bq_source_format = None
+    self._source = None
+    self._source_format = None
+    self._csv_options = None
+    self._ignore_unknown_values = None
+    self._max_bad_records = None
+    self._compressed = None
+    self._schema = None
+
+  @property
+  def schema(self):
+    return self._schema
+
+  def _to_query_json(self):
+    """ Return the table as a dictionary to be used as JSON in a query job. """
+    json = {
+      'compression': 'GZIP' if self._compressed else 'NONE',
+      'ignoreUnknownValues': self._ignore_unknown_values,
+      'maxBadRecords': self._max_bad_records,
+      'sourceFormat': self._bq_source_format,
+      'sourceUris': self._source,
+    }
+    if self._source_format == 'csv' and self._csv_options:
+      json['csvOptions'] = {}
+      json['csvOptions'].update(self._csv_options._to_query_json())
+    if self._schema:
+      json['schema'] = {'fields': self._schema._bq_schema}
+    return json
+

--- a/sources/lib/api/gcp/bigquery/_schema.py
+++ b/sources/lib/api/gcp/bigquery/_schema.py
@@ -277,3 +277,7 @@ class Schema(list):
       if not self._map[name] == other_map[name]:
         return False
     return True
+
+  def __ne__(self, other):
+    """ Compares two schema for inequality. """
+    return not(self.__eq__(other))

--- a/sources/lib/api/gcp/data/_sql_module.py
+++ b/sources/lib/api/gcp/data/_sql_module.py
@@ -122,6 +122,8 @@ class SqlModule(object):
       udfs: a list of UDFs referenced in the query. This supplements args but does not replace
           args, as we want to support passing in UDFs via cell config in magics (which happens
           with args).
+    Returns:
+      The expanded SQL, list of referenced scripts, and list of referenced external tables.
     """
     sql, args = SqlModule.get_sql_statement_with_environment(sql, args)
     return _sql_statement.SqlStatement.format(sql._sql, args, udfs)

--- a/sources/lib/api/gcp/storage/_item.py
+++ b/sources/lib/api/gcp/storage/_item.py
@@ -91,10 +91,16 @@ class Item(object):
     """Returns the key of the item."""
     return self._key
 
+  @property
+  def uri(self):
+    """Returns the gs:// URI for the item.
+    """
+    return 'gs://%s/%s' % (self._bucket, self._key)
+
   def __repr__(self):
     """Returns a representation for the table for showing in the notebook.
     """
-    return 'Item gs://%s/%s' % (self._bucket, self._key)
+    return 'Item %s' % self.uri
 
   def copy_to(self, new_key, bucket=None):
     """Copies this item to the specified new key.

--- a/sources/lib/api/tests/bq_federated_table_tests.py
+++ b/sources/lib/api/tests/bq_federated_table_tests.py
@@ -1,0 +1,165 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+import unittest
+import gcp
+import gcp._util
+import gcp.bigquery
+import mock
+from oauth2client.client import AccessTokenCredentials
+
+
+class TestCases(unittest.TestCase):
+
+  # The main thing we need to test is a query that references an external table and how
+  # that translates into a REST call.
+
+  def _request_result(self):
+    return {
+      'jobReference': {
+        'jobId': 'job1234'
+      },
+      'configuration': {
+        'query': {
+          'destinationTable': {
+            'projectId': 'test',
+            'datasetId': 'dataset',
+            'tableId': 'table'
+          }
+        }
+      },
+      'jobComplete': True
+    }
+
+  def _get_data(self):
+    return [
+      {'day': 1, 'weight': 220},
+      {'day': 2, 'weight': 221},
+      {'day': 3, 'weight': 220},
+      {'day': 4, 'weight': 219},
+      {'day': 5, 'weight': 218},
+    ]
+
+  def _get_table_definition(self, uris, skip_rows=0):
+    if not isinstance(uris, list):
+      uris = [uris]
+    return {
+      'compression': 'NONE',
+      'csvOptions': {
+        'allowJaggedRows': False,
+        'quote': '"',
+        'encoding': 'UTF-8',
+        'skipLeadingRows': skip_rows,
+        'fieldDelimiter': ',',
+        'allowQuotedNewlines': False
+      },
+      'sourceFormat': 'CSV',
+      'maxBadRecords': 0,
+      'ignoreUnknownValues': False,
+      'sourceUris': uris,
+      'schema': {
+        'fields': [
+          {'type': 'INTEGER', 'name': 'day'},
+          {'type': 'INTEGER', 'name': 'weight'}
+        ]
+      }
+    }
+
+  def _get_expected_request_data(self, sql, table_definitions):
+    return {
+      'kind': 'bigquery#job',
+      'configuration': {
+        'priority': 'INTERACTIVE',
+        'query': {
+          'query': sql,
+          'allowLargeResults': False,
+          'tableDefinitions': table_definitions,
+          'useQueryCache': True,
+          'userDefinedFunctionResources': []
+        },
+        'dryRun': False
+      }
+    }
+
+  @mock.patch('gcp._util.Http.request')
+  def test_external_table_query(self, mock_http_request):
+    mock_http_request.return_value = self._request_result()
+
+    data = self._get_data()
+    schema = gcp.bigquery.Schema.from_data(data)
+
+    table_uri = 'gs://datalab/weight.csv'
+    options = gcp.bigquery.CSVOptions(skip_leading_rows=1)
+    sql = 'SELECT * FROM weight'
+
+    weight = gcp.bigquery.FederatedTable.from_storage(table_uri, schema=schema, csv_options=options)
+    q = gcp.bigquery.Query(sql, data_sources={'weight': weight}, context=self._create_context())
+    q.execute_async()
+
+    table_definition = self._get_table_definition(table_uri, skip_rows=1)
+    expected_data = self._get_expected_request_data(sql, {'weight': table_definition})
+    request_url = 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/'
+
+    mock_http_request.assert_called_with(request_url, credentials=mock.ANY, data=expected_data)
+
+  # Test with multiple URLs and no non-default options
+  @mock.patch('gcp._util.Http.request')
+  def test_external_table_query2(self, mock_http_request):
+    mock_http_request.return_value = self._request_result()
+
+    data = self._get_data()
+    schema = gcp.bigquery.Schema.from_data(data)
+
+    table_uris = ['gs://datalab/weight1.csv', 'gs://datalab/weight2.csv']
+    sql = 'SELECT * FROM weight'
+
+    weight = gcp.bigquery.FederatedTable.from_storage(table_uris, schema=schema)
+    q = gcp.bigquery.Query(sql, data_sources={'weight': weight}, context=self._create_context())
+    q.execute_async()
+
+    table_definition = self._get_table_definition(table_uris)
+    expected_data = self._get_expected_request_data(sql, {'weight': table_definition})
+    request_url = 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/'
+
+    mock_http_request.assert_called_with(request_url, credentials=mock.ANY, data=expected_data)
+
+  # Test with multiple tables and using keyword args
+  @mock.patch('gcp._util.Http.request')
+  def test_external_tables_query(self, mock_http_request):
+    mock_http_request.return_value = self._request_result()
+
+    data = self._get_data()
+    schema = gcp.bigquery.Schema.from_data(data)
+
+    table_uri1 = 'gs://datalab/weight1.csv'
+    table_uri2 = 'gs://datalab/weight2.csv'
+    sql = 'SELECT * FROM weight1 JOIN weight2 ON day'
+
+    options = gcp.bigquery.CSVOptions(skip_leading_rows=1)
+    weight1 = gcp.bigquery.FederatedTable.from_storage(table_uri1, schema=schema,
+                                                       csv_options=options)
+    weight2 = gcp.bigquery.FederatedTable.from_storage(table_uri2, schema=schema)
+    q = gcp.bigquery.Query(sql, weight1=weight1, weight2=weight2, context=self._create_context())
+    q.execute_async()
+
+    table_definition1 = self._get_table_definition(table_uri1, skip_rows=1)
+    table_definition2 = self._get_table_definition(table_uri2)
+    table_definitions = {'weight1': table_definition1, 'weight2': table_definition2}
+    expected_data = self._get_expected_request_data(sql, table_definitions)
+    request_url = 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/'
+
+    mock_http_request.assert_called_with(request_url, credentials=mock.ANY, data=expected_data)
+
+  def _create_context(self):
+    project_id = 'test'
+    creds = AccessTokenCredentials('test_token', 'test_ua')
+    return gcp.Context(project_id, creds)

--- a/sources/lib/api/tests/bq_table_tests.py
+++ b/sources/lib/api/tests/bq_table_tests.py
@@ -481,11 +481,14 @@ class TestCases(unittest.TestCase):
       {'insertId': '#3', 'json': {u'column': 'r3', u'headers': 10.0, u'some': 3, 'Row': 3}}
     ])
 
+  @mock.patch('gcp.bigquery._api.Api.tables_get')
   @mock.patch('gcp.bigquery._api.Api.jobs_insert_load')
   @mock.patch('gcp.bigquery._api.Api.jobs_get')
-  def test_table_load(self, mock_api_jobs_get, mock_api_jobs_insert_load):
+  def test_table_load(self, mock_api_jobs_get, mock_api_jobs_insert_load, mock_api_tables_get):
+    schema = self._create_inferred_schema('Row')
     mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_jobs_insert_load.return_value = None
+    mock_api_tables_get.return_value = {'schema': {'fields': schema}}
     tbl = gcp.bigquery.Table('testds.testTable0', context=self._create_context())
     job = tbl.load('gs://foo')
     self.assertIsNone(job)

--- a/sources/lib/api/tests/bq_view_tests.py
+++ b/sources/lib/api/tests/bq_view_tests.py
@@ -85,7 +85,7 @@ class TestCases(unittest.TestCase):
     mock_api_table_update.return_value = None
     friendly_name = 'casper'
     description = 'ghostly logs'
-    sql = 'select * from test:testds.testTable0'
+    sql = 'select * from [test:testds.testTable0]'
     info = {'friendlyName': friendly_name,
             'description': description,
             'view': {'query': sql}}

--- a/sources/lib/api/tests/main.py
+++ b/sources/lib/api/tests/main.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 import bq_api_tests
 import bq_dataset_tests
+import bq_federated_table_tests
 import bq_jobs_tests
 import bq_parser_tests
 import bq_query_tests
@@ -37,6 +38,7 @@ import util_tests
 _TEST_MODULES = [
   bq_api_tests,
   bq_dataset_tests,
+  bq_federated_table_tests,
   bq_jobs_tests,
   bq_parser_tests,
   bq_query_tests,


### PR DESCRIPTION
We leverage the new external tables for loading data from GCS too.
You can now do ExternalTable.load(BQTable). We may want to deprecate
the old Table.load API or make it take an ExternalTable argument to
have a symmetrical Table.load(ExternalTable).

Arguably the naming should be different - ExternalTable.load should
maybe be called ExternalTable.import?