### PR TITLE
Fix a test.

### DIFF
--- a/sources/lib/api/tests/bq_api_tests.py
+++ b/sources/lib/api/tests/bq_api_tests.py
@@ -151,7 +151,7 @@ class TestCases(unittest.TestCase):
       },
     }
     self.maxDiff = None
-    self.validate(mock_http_request, 'https://www.googleapis.com/bigquery/v2/projects/p/jobs/',
+    self.validate(mock_http_request, 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/',
                   expected_data=expected_data)
 
   @mock.patch('gcp._util.Http.request')


### PR DESCRIPTION
This test was broken (correctly) as we made a change recently to fix an
issue where if we were querying a table with a different project we
used that project to run the query. When the bug was fixed the test
was updated to reflect the correct behavior.