### PR TITLE
Fix a minor inefficiency.

### DIFF
--- a/sources/lib/api/gcp/bigquery/_api.py
+++ b/sources/lib/api/gcp/bigquery/_api.py
@@ -115,13 +115,15 @@ class Api(object):
     }
     return gcp._util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_insert_query(self, sql, scripts=None, table_name=None, append=False, overwrite=False,
-                        dry_run=False, use_cache=True, batch=True, allow_large_results=False):
+  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False,
+                        overwrite=False, dry_run=False, use_cache=True, batch=True,
+                        allow_large_results=False):
     """Issues a request to insert a query job.
 
     Args:
       sql: the SQL string representing the query to execute.
-      scripts: code for Javascript UDFs, if any.
+      code: code for Javascript UDFs, if any.
+      imports: a list of GCS URLs containing additional Javascript UDF support code, if any.
       table_name: None for an anonymous table, or a name parts tuple for a long-lived table.
       append: if True, append to the table if it is non-empty; else the request will fail if table
           is non-empty unless overwrite is True.
@@ -155,8 +157,14 @@ class Api(object):
 
     query_config = data['configuration']['query']
 
-    if scripts:
-      query_config['userDefinedFunctionResources'] = [{'inlineCode': script} for script in scripts]
+    resources = []
+    if code:
+      resources.extend([{'inlineCode': fragment} for fragment in code])
+
+    if imports:
+      resources.extend([{'resourceUri': uri} for uri in imports])
+
+    query_config['userDefinedFunctionResources'] = resources
 
     if table_name:
       query_config['destinationTable'] = {

--- a/sources/lib/api/gcp/bigquery/_query.py
+++ b/sources/lib/api/gcp/bigquery/_query.py
@@ -150,12 +150,9 @@ class Query(object):
     Raises:
       An Exception if the query or extract failed.
     """
-    results = self.results(use_cache=use_cache)
-    job = results.extract(storage_uris, format=format, csv_delimiter=csv_delimiter,
-                          csv_header=csv_header, compress=compress)
-    if job is not None:
-      job.wait()
-    return job
+    return self.results(use_cache=use_cache).extract(storage_uris, format=format,
+                                                     csv_delimiter=csv_delimiter,
+                                                     csv_header=csv_header, compress=compress)
 
   @gcp._util.async_method
   def extract_async(self, storage_uris, format='csv', csv_delimiter=',',

--- a/sources/lib/api/gcp/bigquery/_query_results_table.py
+++ b/sources/lib/api/gcp/bigquery/_query_results_table.py
@@ -42,7 +42,7 @@ class QueryResultsTable(_table.Table):
     if self._is_temporary:
       return 'QueryResultsTable %s' % self.job_id
     else:
-      super.__repr__()
+      return super(QueryResultsTable, self).__repr__()
 
   @property
   def job(self):

--- a/sources/lib/api/gcp/bigquery/_udf.py
+++ b/sources/lib/api/gcp/bigquery/_udf.py
@@ -13,64 +13,47 @@
 """Google Cloud Platform library - BigQuery UDF Functionality."""
 
 import json
+import gcp.storage
 
 
-class FunctionCall(object):
-  """Represents a BigQuery UDF invocation.
+class UDF(object):
+  """Represents a BigQuery UDF declaration.
   """
 
-  def __init__(self, data, inputs, outputs, name, implementation):
-    """Initializes a UDF object from its pieces.
+  @property
+  def name(self):
+    return self._name
+
+  @property
+  def imports(self):
+    return self._imports
+
+  @property
+  def code(self):
+    return self._code
+
+  def __init__(self, inputs, outputs, name, implementation, support_code=None, imports=None):
+    """Initializes a Function object from its pieces.
 
     Args:
-      data: the query or table over which the UDF operates.
       inputs: a list of string field names representing the schema of input.
       outputs: a list of name/type tuples representing the schema of the output.
-      name: the name of the UDF function
+      name: the name of the javascript function
       implementation: a javascript function implementing the logic.
-    """
-    self._sql = FunctionCall._build_sql(name, inputs, data)
-    self._code = FunctionCall._build_js(inputs, outputs, name, implementation)
-
-  @property
-  def sql(self):
-    """Gets the underlying SQL representation of this UDF object."""
-    return self._sql
-
-  @property
-  def js(self):
-    """Gets the underlying JS representation of this UDF object."""
-    return self._code
-
-  def _repr_sql_(self):
-    """Returns a SQL representation of the UDF object.
-
-    Returns:
-      A SQL string that can be embedded in another SQL statement.
-    """
-    return self._sql
-
-  def _repr_code_(self):
-    """Returns a JS representation of the UDF object.
-
-    Returns:
-      A JS string that can be submitted with a BQ Query.
-    """
-    return self._code
+      support_code: additional javascript code that the function can use.
+      imports: a list of GCS URLs or files containing further support code.
+    Raises:
+      Exception if the name is invalid.
+      """
+    self._outputs = outputs
+    self._name = name
+    self._implementation = implementation
+    self._support_code = support_code
+    self._imports = imports
+    self._code = UDF._build_js(inputs, outputs, name, implementation, support_code)
 
   @staticmethod
-  def _build_sql(name, inputs, data):
-    """Creates a BigQuery SQL UDF query invocation object.
-
-    Args:
-      name: the name of the UDF function
-      inputs: a list of (name, type) tuples representing the schema of input.
-      data: the query or table over which the UDF operates.
-    """
-    return '(SELECT %s FROM %s(%s))' % (', '.join([f[0] for f in inputs]), name, data._repr_sql_())
-
-  @staticmethod
-  def _build_js(inputs, outputs, name, implementation):
+  def _build_js(inputs, outputs, name, implementation, support_code):
     """Creates a BigQuery SQL UDF javascript object.
 
     Args:
@@ -78,6 +61,7 @@ class FunctionCall(object):
       outputs: a list of (name, type) tuples representing the schema of the output.
       name: the name of the function
       implementation: a javascript function defining the UDF logic.
+      support_code: additional javascript code that the function can use.
     """
     # Construct a comma-separated list of input field names
     # For example, field1,field2,...
@@ -89,50 +73,13 @@ class FunctionCall(object):
     output_fields = json.dumps(output_fields, sort_keys=True)
 
     # Build the JS from the individual bits with proper escaping of the implementation
-    return '%s=%s;\nbigquery.defineFunction(\'%s\', %s, %s, %s);' %\
-           (name, implementation.replace('"', '\\"'), name, input_fields, output_fields, name)
+    if support_code is None:
+      support_code = ''
+    return ('{code}\n{name}={implementation};\n' + \
+            'bigquery.defineFunction(\'{name}\', {inputs}, {outputs}, {name});')\
+                .format(code=support_code,
+                        name=name,
+                        implementation=implementation,
+                        inputs=str(input_fields),
+                        outputs=str(output_fields))
 
-
-class FunctionEvaluation(object):
-
-  def __init__(self, implementation, data):
-    self._implementation = implementation
-    self._data = data
-
-  @property
-  def data(self):
-    return self._data
-
-  @property
-  def implementation(self):
-    return self._implementation
-
-
-class UDF(object):
-  """Represents a BigQuery UDF declaration.
-  """
-
-  def __init__(self, inputs, outputs, name, implementation):
-    """Initializes a Function object from its pieces.
-
-    Args:
-      inputs: a list of string field names representing the schema of input.
-      outputs: a list of name/type tuples representing the schema of the output.
-      name: the name of the javascript function
-      implementation: a javascript function implementing the logic.
-    Raises:
-      Exception if the name is invalid.
-      """
-    self._inputs = inputs
-    self._outputs = outputs
-    self._name = name
-    self._implementation = implementation
-
-  def __call__(self, data):
-    if issubclass(type(data), list):
-      return FunctionEvaluation(self._implementation, data)
-    else:
-      return FunctionCall(data, self._inputs, self._outputs, self._name, self._implementation)
-
-  def __repr_js__(self):
-    return self._implementation

--- a/sources/lib/api/gcp/data/__init__.py
+++ b/sources/lib/api/gcp/data/__init__.py
@@ -27,10 +27,109 @@ def sql(sql_template, **kwargs):
     sql_template: the template of the SQL statement with named placeholders.
     **kwargs: the dictionary of name/value pairs to use for placeholder values.
   Returns:
-    The formatted SQL statement with placeholders replaced with their values, and
-    an array of Javascript UDFs referenced by the code.
+    The formatted SQL statement with placeholders replaced with their values.
   Raises:
     Exception if a placeholder was found in the SQL statement, but did not have
     a corresponding argument value.
   """
-  return SqlStatement.format(sql_template, kwargs)
+  return _util.Sql.format(sql_template, kwargs)
+
+
+def _next_token(sql):
+  """ This is a basic tokenizer for our limited purposes.
+  It splits a SQL statement up into a series of segments, where a segment is one of:
+  - identifiers
+  - left or right parentheses
+  - multi-line comments
+  - single line comments
+  - white-space sequences
+  - string literals
+  - consecutive strings of characters that are not one of the items above
+
+  The aim is for us to be able to find function calls (identifiers followed by '('), and the
+  associated closing ')') so we can augment these if needed.
+
+  Args:
+    sql: a SQL statement as a (possibly multi-line) string.
+
+  Returns:
+    For each call, the next token in the initial input.
+  """
+  i = 0
+
+  # We use some lambda's to make the logic more clear. The start_* functions return
+  # true if i is the index of the start of that construct, while the end_* functions
+  # return true if i point to the first character beyond that construct or the end of the
+  # content.
+  #
+  # We don't currently need numbers so the tokenizer here just does sequences of
+  # digits as a convenience to shrink the total number of tokens. If we needed numbers
+  # later we would need a special handler for these much like strings.
+
+  start_multi_line_comment = lambda s, i: s[i] == '/' and i < len(s) - 1 and s[i + 1] == '*'
+  end_multi_line_comment = lambda s, i: s[i - 2] == '*' and s[i - 1] == '/'
+  start_single_line_comment = lambda s, i: s[i] == '-' and i < len(s) - 1 and s[i + 1] == '-'
+  end_single_line_comment = lambda s, i: s[i - 1] == '\n'
+  start_whitespace = lambda s, i: s[i].isspace()
+  end_whitespace = lambda s, i: not s[i].isspace()
+  start_number = lambda s, i: s[i].isdigit()
+  end_number = lambda s, i: not s[i].isdigit()
+  start_identifier = lambda s, i: s[i].isalpha() or s[i] == '_' or s[i] == '$'
+  end_identifier = lambda s, i: not(s[i].isalnum() or s[i] == '_')
+  start_string = lambda s, i: s[i] =='"' or s[i] == "'"
+  always_true = lambda s, i: True
+
+  while i < len(sql):
+    start = i
+    if start_multi_line_comment(sql, i):
+      i += 1
+      end_checker = end_multi_line_comment
+    elif start_single_line_comment(sql, i):
+      i += 1
+      end_checker = end_single_line_comment
+    elif start_whitespace(sql, i):
+      end_checker = end_whitespace
+    elif start_identifier(sql, i):
+      end_checker = end_identifier
+    elif start_number(sql, i):
+      end_checker = end_number
+    elif start_string(sql, i):
+      # Special handling here as we need to check for escaped closing quotes.
+      quote = sql[i]
+      end_checker = always_true
+      i += 1
+      while i < len(sql) and sql[i] != quote:
+        i += 2 if sql[i] == '\\' else 1
+    else:
+      # We return single characters for everything else
+      end_checker = always_true
+
+    i += 1
+    while i < len(sql) and not end_checker(sql, i):
+      i += 1
+
+    (yield sql[start:i])
+
+
+def tokenize(sql):
+  """ This is a basic tokenizer for our limited purposes.
+  It splits a SQL statement up into a series of segments, where a segment is one of:
+  - identifiers
+  - left or right parentheses
+  - multi-line comments
+  - single line comments
+  - white-space sequences
+  - string literals
+  - consecutive strings of characters that are not one of the items above
+
+  The aim is for us to be able to find function calls (identifiers followed by '('), and the
+  associated closing ')') so we can augment these if needed.
+
+  Args:
+    sql: a SQL statement as a (possibly multi-line) string.
+
+  Returns:
+    A list of strings corresponding to the groups above.
+  """
+  return list(_next_token(sql))
+

--- a/sources/lib/api/gcp/data/__init__.py
+++ b/sources/lib/api/gcp/data/__init__.py
@@ -33,4 +33,4 @@ def sql(sql_template, **kwargs):
     Exception if a placeholder was found in the SQL statement, but did not have
     a corresponding argument value.
   """
-  return _util.Sql.format(sql_template, kwargs)
+  return SqlStatement.format(sql_template, kwargs)

--- a/sources/lib/api/gcp/data/_sql_module.py
+++ b/sources/lib/api/gcp/data/_sql_module.py
@@ -97,8 +97,11 @@ class SqlModule(object):
     env = {}
     if item.module:
       env.update(item.module.__dict__)
-      args = SqlModule._get_sql_args(
-        env.get(SqlModule._SQL_MODULE_ARGPARSE, None), args=args)
+      parser = env.get(SqlModule._SQL_MODULE_ARGPARSE, None)
+      if parser:
+        args = SqlModule._get_sql_args(parser, args=args)
+      else:
+        args = None
 
     if isinstance(args, dict):
       env.update(args)

--- a/sources/lib/api/gcp/data/_sql_module.py
+++ b/sources/lib/api/gcp/data/_sql_module.py
@@ -109,7 +109,7 @@ class SqlModule(object):
     return item, env
 
   @staticmethod
-  def expand(sql, args=None):
+  def expand(sql, args=None, udfs=None):
     """ Expand a SqlStatement, query string or SqlModule with a set of arguments.
 
     Args:
@@ -119,9 +119,12 @@ class SqlModule(object):
           SqlModule. If a dictionary, it is used to override any default arguments from the
           argument parser. If the sql argument is a string then args must be None or a dictionary
           as in this case there is no associated argument parser.
+      udfs: a list of UDFs referenced in the query. This supplements args but does not replace
+          args, as we want to support passing in UDFs via cell config in magics (which happens
+          with args).
     """
     sql, args = SqlModule.get_sql_statement_with_environment(sql, args)
-    return _sql_statement.SqlStatement.format(sql._sql, args)
+    return _sql_statement.SqlStatement.format(sql._sql, args, udfs)
 
 
 import _sql_statement

--- a/sources/lib/api/gcp/storage/_item.py
+++ b/sources/lib/api/gcp/storage/_item.py
@@ -81,6 +81,11 @@ class Item(object):
     self._key = key
     self._info = info
 
+  @staticmethod
+  def from_url(url):
+    bucket, item = _bucket.parse_name(url)
+    return Item(bucket, item)
+
   @property
   def key(self):
     """Returns the key of the item."""
@@ -239,3 +244,6 @@ class Items(object):
 
   def __iter__(self):
     return iter(gcp._util.Iterator(self._retrieve_items))
+
+
+import _bucket

--- a/sources/lib/api/tests/bq_api_tests.py
+++ b/sources/lib/api/tests/bq_api_tests.py
@@ -116,6 +116,7 @@ class TestCases(unittest.TestCase):
         'query': {
           'query': 'SQL',
           'useQueryCache': True,
+          'userDefinedFunctionResources': [],
           'allowLargeResults': False
         },
         'dryRun': False,
@@ -124,7 +125,8 @@ class TestCases(unittest.TestCase):
     }
     self.validate(mock_http_request, 'https://www.googleapis.com/bigquery/v2/projects/test/jobs/',
                   expected_data=expected_data)
-    api.jobs_insert_query('SQL2', ['CODE'], gcp.bigquery._utils.TableName('p', 'd', 't', ''),
+    api.jobs_insert_query('SQL2', ['CODE'],
+                          table_name=gcp.bigquery._utils.TableName('p', 'd', 't', ''),
                           append=True, dry_run=True, use_cache=False, batch=False,
                           allow_large_results=True)
     expected_data = {

--- a/sources/lib/api/tests/sql_tests.py
+++ b/sources/lib/api/tests/sql_tests.py
@@ -13,24 +13,73 @@
 import imp
 import unittest
 
-from gcp.data import SqlModule, SqlStatement
+from gcp.data import SqlModule, SqlStatement, tokenize
 
 
 class TestCases(unittest.TestCase):
+
+  def test_sql_tokenizer(self):
+    query = "SELECT * FROM function(SELECT * FROM [table])  -- a comment\nWHERE x>0 AND y == 'cat'/*\nmulti-line comment */LIMIT 10"
+    tokens = tokenize(query)
+    # Make sure we get all the content
+    self.assertEquals(''.join(tokens), query)
+
+    # Then check the tokens
+    expected = [
+      'SELECT',
+      ' ',
+      '*',
+      ' ',
+      'FROM',
+      ' ',
+      'function',
+      '(',
+      'SELECT',
+      ' ',
+      '*',
+      ' ',
+      'FROM',
+      ' ',
+      '[',
+      'table',
+      ']',
+      ')',
+      '  ',
+      '-- a comment\n',
+      'WHERE',
+      ' ',
+      'x',
+      '>',
+      '0',
+      ' ',
+      'AND',
+      ' ',
+      'y',
+      ' ',
+      '=',
+      '=',
+      ' ',
+      '\'cat\'',
+      '/*\nmulti-line comment */',
+      'LIMIT',
+      ' ',
+      '10'
+    ]
+    self.assertEquals(expected, tokens)
 
   def test_zero_placeholders(self):
     queries = ['SELECT * FROM [logs.today]',
                ' SELECT time FROM [logs.today] ']
 
     for query in queries:
-      formatted_query = SqlStatement.format(query, None)[0]
+      formatted_query = SqlStatement.format(query, None)
       self.assertEqual(query, formatted_query)
 
   def test_single_placeholder(self):
     query = 'SELECT time FROM [logs.today] WHERE status == $param'
     args = {'param': 200}
 
-    formatted_query = SqlStatement.format(query, args)[0]
+    formatted_query = SqlStatement.format(query, args)
     self.assertEqual(formatted_query,
                      'SELECT time FROM [logs.today] WHERE status == 200')
 
@@ -39,7 +88,7 @@ class TestCases(unittest.TestCase):
              'WHERE status == $status AND path == $path')
     args = {'status': 200, 'path': '/home'}
 
-    formatted_query = SqlStatement.format(query, args)[0]
+    formatted_query = SqlStatement.format(query, args)
     self.assertEqual(formatted_query,
                      ('SELECT time FROM [logs.today] '
                       'WHERE status == 200 AND path == "/home"'))
@@ -48,7 +97,7 @@ class TestCases(unittest.TestCase):
     query = 'SELECT time FROM [logs.today] WHERE path == "/foo$$bar"'
     args = {'status': 200}
 
-    formatted_query = SqlStatement.format(query, args)[0]
+    formatted_query = SqlStatement.format(query, args)
     self.assertEqual(formatted_query,
                      'SELECT time FROM [logs.today] WHERE path == "/foo$bar"')
 
@@ -56,7 +105,7 @@ class TestCases(unittest.TestCase):
     query = 'SELECT time FROM [logs.today] WHERE path == $path'
     args = {'path': 'xyz"xyz'}
 
-    formatted_query = SqlStatement.format(query, args)[0]
+    formatted_query = SqlStatement.format(query, args)
     self.assertEqual(formatted_query,
                      'SELECT time FROM [logs.today] WHERE path == "xyz\\"xyz"')
 
@@ -76,7 +125,7 @@ class TestCases(unittest.TestCase):
                       'WHERE success == False AND server == "$master" '
                       'LIMIT 10')
 
-    formatted_query = SqlStatement.format(query, args)[0]
+    formatted_query = SqlStatement.format(query, args)
 
     self.assertEqual(formatted_query, expected_query)
 
@@ -85,7 +134,7 @@ class TestCases(unittest.TestCase):
     args = {'s': 200}
 
     with self.assertRaises(Exception) as error:
-      _ = SqlStatement.format(query, args)[0]
+      _ = SqlStatement.format(query, args)
 
     e = error.exception
     self.assertEqual(e.message, 'Unsatisfied dependency $status')
@@ -102,26 +151,26 @@ class TestCases(unittest.TestCase):
     self.assertEquals('Unsatisfied dependency $query2', e.exception.message)
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format(query3, {'query1': query1})[0]
+      _ = SqlStatement.format(query3, {'query1': query1})
     self.assertEquals('Unsatisfied dependency $query2', e.exception.message)
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format(query3, {'query2': query2})[0]
+      _ = SqlStatement.format(query3, {'query2': query2})
     self.assertEquals('Unsatisfied dependency $query1', e.exception.message)
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format(query3, {'query1': query1, 'query2': query2})[0]
+      _ = SqlStatement.format(query3, {'query1': query1, 'query2': query2})
     self.assertEquals('Unsatisfied dependency $count', e.exception.message)
 
     formatted_query =\
-        SqlStatement.format(query3, {'query1': query1, 'query2': query2, 'count': 5})[0]
+        SqlStatement.format(query3, {'query1': query1, 'query2': query2, 'count': 5})
     self.assertEqual('SELECT * FROM (SELECT x FROM (SELECT 3 as x)) WHERE x == 5', formatted_query)
 
   def test_shared_nested_queries(self):
     query1 = SqlStatement('SELECT 3 as x')
     query2 = SqlStatement('SELECT x FROM $query1')
     query3 = 'SELECT x AS y FROM $query1, x FROM $query2'
-    formatted_query = SqlStatement.format(query3, {'query1': query1, 'query2': query2})[0]
+    formatted_query = SqlStatement.format(query3, {'query1': query1, 'query2': query2})
     self.assertEqual('SELECT x AS y FROM (SELECT 3 as x), x FROM (SELECT x FROM (SELECT 3 as x))',
                      formatted_query)
 
@@ -132,15 +181,15 @@ class TestCases(unittest.TestCase):
     args = {'query1': query1, 'query2': query2, 'query3': query3}
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format('SELECT * FROM $query1', args)[0]
+      _ = SqlStatement.format('SELECT * FROM $query1', args)
     self.assertEquals('Circular dependency in $query1', e.exception.message)
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format('SELECT * FROM $query2', args)[0]
+      _ = SqlStatement.format('SELECT * FROM $query2', args)
     self.assertEquals('Circular dependency in $query2', e.exception.message)
 
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format('SELECT * FROM $query3', args)[0]
+      _ = SqlStatement.format('SELECT * FROM $query3', args)
     self.assertEquals('Circular dependency in $query3', e.exception.message)
 
   def test_module_reference(self):
@@ -149,13 +198,13 @@ class TestCases(unittest.TestCase):
     m.__dict__[SqlModule._SQL_MODULE_LAST] =\
         m.__dict__[SqlModule._SQL_MODULE_LAST] = SqlStatement('SELECT * FROM $q1 LIMIT 10')
     with self.assertRaises(Exception) as e:
-      _ = SqlStatement.format('SELECT * FROM $s', {'s': m})[0]
+      _ = SqlStatement.format('SELECT * FROM $s', {'s': m})
     self.assertEquals('Unsatisfied dependency $q1', e.exception.message)
 
-    formatted_query = SqlStatement.format('SELECT * FROM $s', {'s': m, 'q1': m.q1})[0]
+    formatted_query = SqlStatement.format('SELECT * FROM $s', {'s': m, 'q1': m.q1})
     self.assertEqual('SELECT * FROM (SELECT * FROM (SELECT 3 AS x) LIMIT 10)', formatted_query)
 
-    formatted_query = SqlStatement.format('SELECT * FROM $s', {'s': m.q1})[0]
+    formatted_query = SqlStatement.format('SELECT * FROM $s', {'s': m.q1})
     self.assertEqual('SELECT * FROM (SELECT 3 AS x)', formatted_query)
 
   def test_get_sql_statement_with_environment(self):

--- a/sources/lib/datalab/tests/bigquery_tests.py
+++ b/sources/lib/datalab/tests/bigquery_tests.py
@@ -57,8 +57,6 @@ function(r, emitFn) {
     udf = env['word_filter']
     self.assertIsNotNone(udf)
     self.assertEquals('word_filter', udf._name)
-    self.assertEquals([('word', 'string'), ('corpus', 'string'), ('word_count', 'integer')],
-                      udf._inputs)
     self.assertEquals([('word', 'string'), ('corpus', 'string'), ('count', 'integer')],
                       udf._outputs)
     self.assertEquals(cell_body, udf._implementation)

--- a/sources/web/datalab/workspaceManager.ts
+++ b/sources/web/datalab/workspaceManager.ts
@@ -192,7 +192,7 @@ export function scheduleWorkspaceUpdate(userId: string) {
         if (syncRequests[userId] < MAX_SYNC_RETRY) {
           logging.getLogger().info('Reschedule sync for user: %s for %d times.',
                                    userId, syncRequests[userId]);
-          scheduleWorkspaceUpdate(userId);
+          setTimeout(deferredUpdate, MIN_SYNC_INTERVAL);
         }
         else {
           // TODO: Store a sync status for the user, so it can be reported


### PR DESCRIPTION
Query.export calls Table.export. The latter blocks waiting for the Job
to complete and returns the Job. Query.export then calls wait() on the
Job too; this is benign but unneccessary. Simplifying the code.