### PR TITLE
Feature/auth

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -97,7 +97,8 @@ RUN mkdir -p /datalab/web && \
         node-uuid@1.4.3 \
         bunyan@1.4.0 \
         socket.io@1.3.6 \
-        tcp-port-used@0.1.2 && \
+        tcp-port-used@0.1.2 \
+        googleapis@2.1.3 && \
     cd / && \
     /tools/node/bin/npm install -g forever
 

--- a/content/datalab/intro/Managing Datalab - Authentication.ipynb
+++ b/content/datalab/intro/Managing Datalab - Authentication.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Manageing Datalab - Authentication"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Datalab has its own \"allowed users\" list. By default, project owners and editors are added to the list and have access to the Datalab instance(s) in the same project automatically, while readers don't have access to it.\n",
+    "\n",
+    "Here is what happens in authentication when a user visits Datalab in a project.\n",
+    "\n",
+    "1. A user is added as editor to the target project with Datalab instance deployed.\n",
+    "\n",
+    "2. When the user visits Datalab in this project, Datalab checks if the user is allowed to access by looking at the project's Datastore. If there is an entity with kind = 'DatalabUser' and name = [UserEmail], then the request passes through. It does the same for every request.\n",
+    "\n",
+    "3. If the Datastore entity does not exist, Datalab will redirect user to the Datalab service page (https://datalab.cloud.google.com), and the user needs to sign in from there.\n",
+    "\n",
+    "4. After the user signs in, Datalab service will try to add the Datastore entity (kind = 'DatalabUser' and name = [UserEmail]) into the target project with the user's access token. Only project editors and owners can add a Datastore entity. If it fails, the user is not an owner or editor, and an alert box will show up. If it succeeds, Datalab service will redirect the user to the target Datalab page, where Datalab sees the entity and allows the request to be served."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the Datastore entity corresponding to a user is added, if an administrator wants to revoke the user's access to datalab, he/she needs to do the following:\n",
+    "\n",
+    "1. Remove the Datastore entity corresponding to the user. For example, go to Developer Console, Storage, Datastore, and remove the entity.\n",
+    "\n",
+    "2. Go to Developer Console and set the user as a reader to the project.\n",
+    "\n",
+    "\n",
+    "Or, an administrator can simply remove the user from the project. Then AppEngine will not allow the user to access any applications inside the project, including Datalab."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/sources/web/datalab/authentication.ts
+++ b/sources/web/datalab/authentication.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../../externs/ts/node/node.d.ts" />
+/// <reference path="common.d.ts" />
+
+
+import logging = require('./logging');
+var googleapis = require('googleapis');
+
+/**
+ * The datastore service used to query Datastore to see if a user is whitelisted.
+ */
+var datastore : any;
+
+/**
+ * The authentication Url that it will redirect users to if needed.
+ */
+var authUrl: string;
+
+/**
+ * Checks whether a given user has access to this instance of Datalab.
+ */
+export function checkUserAccess(userId: string, cb: common.Callback<boolean>) {
+  datastore.datasets.lookup(
+    {
+      resource: {
+        keys: [{path: [{kind: 'DatalabUser', name: userId}]}]
+      }
+    },
+    function(e: Error, result: any) {
+      if (e) {
+        logging.getLogger().error(e, 'Failed to look up user.');
+      }
+      var found: boolean = result && result.found && (result.found.length > 0);
+      cb && cb(e, found);
+    }
+  );
+}
+
+/**
+ * Checks whether a given user has access to this instance of Datalab.
+ */
+export function getAuthenticationUrl(): string {
+  return authUrl;
+}
+
+export function init(settings: common.Settings, cb: common.Callback0) : void {
+  authUrl = "http://stage-dot-cloud-datalab-deploy.appspot.com?startinproject="
+            + settings.projectId + "&name=" + settings.instanceName;
+
+  var compute = new googleapis.auth.Compute();
+  if (settings.metadataHost) {
+    logging.getLogger().info("overriding auth url");
+    // For local run, we change the token url to be a local metadata server
+    // by overriding its options.
+    compute.opts.tokenUrl = "http://" + settings.metadataHost
+      + "/computemetadata/v1/instance/service-accounts/default/token";
+  }
+
+  compute.getAccessToken(function(e: Error, token: string) {
+    if (e) {
+      logging.getLogger().error(e, 'Failed to get service account access token');
+      cb && cb(e);
+    } 
+    else {
+      datastore = googleapis.datastore({
+        version: 'v1beta2',
+        auth: compute,
+        projectId: settings.projectId,
+        params: {datasetId: settings.projectId}
+      });
+      logging.getLogger().info("Successfully got access token and created datastore service");
+      cb && cb(null);
+    }
+  });
+}

--- a/sources/web/datalab/authentication.ts
+++ b/sources/web/datalab/authentication.ts
@@ -20,7 +20,7 @@ import logging = require('./logging');
 var googleapis = require('googleapis');
 
 /**
- * The datastore service used to query Datastore to see if a user is whitelisted.
+ * The datastore service used to query Datastore to see if a user is allowed to access.
  */
 var datastore : any;
 
@@ -57,14 +57,13 @@ export function getAuthenticationUrl(): string {
 }
 
 export function init(settings: common.Settings, cb: common.Callback0) : void {
-  authUrl = "http://stage-dot-cloud-datalab-deploy.appspot.com?startinproject="
+  authUrl = "https://datalab.cloud.google.com?startinproject="
             + settings.projectId + "&name=" + settings.instanceName;
 
   var compute = new googleapis.auth.Compute();
   if (settings.metadataHost) {
-    logging.getLogger().info("overriding auth url");
-    // For local run, we change the token url to be a local metadata server
-    // by overriding its options.
+    logging.getLogger().info("overriding metadata url.");
+    // For local run, we change the token url to point to a local metadata server.
     compute.opts.tokenUrl = "http://" + settings.metadataHost
       + "/computemetadata/v1/instance/service-accounts/default/token";
   }
@@ -81,7 +80,7 @@ export function init(settings: common.Settings, cb: common.Callback0) : void {
         projectId: settings.projectId,
         params: {datasetId: settings.projectId}
       });
-      logging.getLogger().info("Successfully got access token and created datastore service");
+      logging.getLogger().info("Successfully got access token and created datastore service.");
       cb && cb(null);
     }
   });

--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -71,6 +71,13 @@ declare module common {
      * Useful when debugging multi-user functionality locally.
      */
     supportUserOverride: boolean;
+
+    /**
+     * Metadata host name. If specified, will override the default
+     * metadata host in AppEngine VM, mostly for local run so that
+     * the service account access token will be available locally.
+     */
+    metadataHost: string;
   }
 
   interface Map<T> {

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -63,6 +63,7 @@ export function loadSettings(): common.Settings {
     settings.projectId = process.env['DATALAB_PROJECT_ID'] || '';
     settings.projectNumber = process.env['DATALAB_PROJECT_NUM'] || '';
     settings.versionId = process.env['DATALAB_VERSION'] || '';
+    settings.metadataHost = process.env['METADATA_HOST'] || '';
     if (!settings.analyticsId) {
       settings.analyticsId = process.env['DATALAB_ANALYTICS_ID'] || '';
     }


### PR DESCRIPTION
Feature: Only allow editors and owners of the project to access Datalab.

Tests done:

- With user entity in Datastore of the project, the user is able to access.
- Without user entity, the user is redirected to deployer page, where he/she can sign in, and then redirected back.
- Works in both locally and in cloud.

