### PR TITLE
Feature/auth

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -97,7 +97,8 @@ RUN mkdir -p /datalab/web && \
         node-uuid@1.4.3 \
         bunyan@1.4.0 \
         socket.io@1.3.6 \
-        tcp-port-used@0.1.2 && \
+        tcp-port-used@0.1.2 \
+        node-cache@3.0.0 && \
     cd / && \
     /tools/node/bin/npm install -g forever
 

--- a/content/datalab/intro/Managing Datalab - Authentication.ipynb
+++ b/content/datalab/intro/Managing Datalab - Authentication.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Manageing Datalab - Authentication"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Datalab has its own \"allowed users\" list. By default, project owners and editors are added to the list and have access to the Datalab instance(s) in the same project automatically, while readers don't have access to it.\n",
+    "\n",
+    "Here is what happens in authentication when a user visits Datalab in a project.\n",
+    "\n",
+    "1. A user is added as editor to the target project with Datalab instance deployed.\n",
+    "\n",
+    "2. When the user visits Datalab in this project, Datalab checks if the user is allowed to access by looking at the project's Datastore. If there is an entity with kind = 'DatalabUser' and name = [UserEmail], then the request passes through. It does the same for every request.\n",
+    "\n",
+    "3. If the Datastore entity does not exist, Datalab will redirect user to the Datalab service page (https://datalab.cloud.google.com), and the user needs to sign in from there.\n",
+    "\n",
+    "4. After the user signs in, Datalab service will try to add the Datastore entity (kind = 'DatalabUser' and name = [UserEmail]) into the target project with the user's access token. Only project editors and owners can add a Datastore entity. If it fails, the user is not an owner or editor, and an alert box will show up. If it succeeds, Datalab service will redirect the user to the target Datalab page, where Datalab sees the entity and allows the request to be served."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the Datastore entity corresponding to a user is added, if an administrator wants to revoke the user's access to datalab, he/she needs to do the following:\n",
+    "\n",
+    "1. Remove the Datastore entity corresponding to the user. For example, go to Developer Console, Storage, Datastore, and remove the entity.\n",
+    "\n",
+    "2. Go to Developer Console and set the user as a reader to the project.\n",
+    "\n",
+    "\n",
+    "Or, an administrator can simply remove the user from the project. Then AppEngine will not allow the user to access any applications inside the project, including Datalab."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/externs/ts/node/node-cache.d.ts
+++ b/externs/ts/node/node-cache.d.ts
@@ -1,0 +1,263 @@
+// Type definitions for node-cache v3.0.0
+// Project: https://github.com/tcs-de/nodecache
+// Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module NodeCacheTypes {
+    interface NodeCache {
+        /** container for cached data */
+        data: Data;
+
+        /** module options */
+        options: Options;
+
+        /** statistics container */
+        stats: Stats;
+
+        /**
+         * get a cached key and change the stats
+         *
+         * @param key cache key or an array of keys
+         * @param cb Callback function
+         */
+        get<T>(
+            key: string,
+            cb?: Callback<T>
+        ): T;
+
+        /**
+         * get multiple cached keys at once and change the stats
+         *
+         * @param keys an array of keys
+         * @param cb Callback function
+         */
+        mget<T>(
+            keys: string[],
+            cb?: Callback<{[key: string]: T}>
+        ): {[key: string]: T};
+
+        /**
+         * set a cached key and change the stats
+         *
+         * @param key cache key
+         * @param value A element to cache. If the option `option.forceString` is `true` the module trys to translate
+         * it to a serialized JSON
+         * @param ttl The time to live in seconds.
+         * @param cb Callback function
+         */
+        set<T>(
+            key: string,
+            value: T,
+            ttl: number|string,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        set<T>(
+            key: string,
+            value: T,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        /**
+         * remove keys
+         * @param keys cache key to delete or a array of cache keys
+         * @param cb Callback function
+         * @returns Number of deleted keys
+         */
+        del(
+            keys: string|string[],
+            cb?: Callback<number>
+        ): number;
+
+        /**
+         * reset or redefine the ttl of a key. If `ttl` is not passed or set to 0 it's similar to `.del()`
+         */
+        ttl(
+            key: string,
+            ttl: number,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        ttl(
+            key: string,
+            cb?: Callback<boolean>,
+            ttl?: number
+        ): boolean;
+
+        /**
+         * list all keys within this cache
+         * @param cb Callback function
+         * @returns An array of all keys
+         */
+        keys(cb?: Callback<string[]>): string[];
+
+        /**
+         * get the stats
+         *
+         * @returns Stats data
+         */
+        getStats(): Stats;
+
+        /**
+         * flush the hole data and reset the stats
+         */
+        flushAll(): void;
+
+        /**
+         * This will clear the interval timeout which is set on checkperiod option.
+         */
+        close(): void;
+    }
+
+    interface Data {
+        [key: string]: WrappedValue<any>;
+    }
+
+    interface Options {
+        forceString: boolean;
+        objectValueSize: number;
+        arrayValueSize: number;
+        stdTTL: number;
+        checkperiod: number;
+        useClones: boolean;
+    }
+
+    interface Stats {
+        hits: number;
+        misses: number;
+        keys: number;
+        ksize: number;
+        vsize: number;
+    }
+
+    interface WrappedValue<T> {
+        // ttl
+        t: number;
+        // value
+        v: T;
+    }
+
+    interface Callback<T> {
+        (err: any, data: T): void;
+    }
+}
+
+declare module "node-cache" {
+    import events = require("events");
+
+    import Data = NodeCacheTypes.Data;
+    import Options = NodeCacheTypes.Options;
+    import Stats = NodeCacheTypes.Stats;
+    import Callback = NodeCacheTypes.Callback;
+
+    class NodeCache extends events.EventEmitter implements NodeCacheTypes.NodeCache {
+        /** container for cached data */
+        data: Data;
+
+        /** module options */
+        options: Options;
+
+        /** statistics container */
+        stats: Stats;
+
+        constructor(options?: Options);
+
+        /**
+         * get a cached key and change the stats
+         *
+         * @param key cache key or an array of keys
+         * @param cb Callback function
+         */
+        get<T>(
+            key: string,
+            cb?: Callback<T>
+        ): T;
+
+        /**
+         * get multiple cached keys at once and change the stats
+         *
+         * @param keys an array of keys
+         * @param cb Callback function
+         */
+        mget<T>(
+            keys: string[],
+            cb?: Callback<{[key: string]: T}>
+        ): {[key: string]: T};
+
+        /**
+         * set a cached key and change the stats
+         *
+         * @param key cache key
+         * @param value A element to cache. If the option `option.forceString` is `true` the module trys to translate
+         * it to a serialized JSON
+         * @param ttl The time to live in seconds.
+         * @param cb Callback function
+         */
+        set<T>(
+            key: string,
+            value: T,
+            ttl: number|string,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        set<T>(
+            key: string,
+            value: T,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        /**
+         * remove keys
+         * @param keys cache key to delete or a array of cache keys
+         * @param cb Callback function
+         * @returns Number of deleted keys
+         */
+        del(
+            keys: string|string[],
+            cb?: Callback<number>
+        ): number;
+
+        /**
+         * reset or redefine the ttl of a key. If `ttl` is not passed or set to 0 it's similar to `.del()`
+         */
+        ttl(
+            key: string,
+            ttl: number,
+            cb?: Callback<boolean>
+        ): boolean;
+
+        ttl(
+            key: string,
+            cb?: Callback<boolean>,
+            ttl?: number
+        ): boolean;
+
+        /**
+         * list all keys within this cache
+         * @param cb Callback function
+         * @returns An array of all keys
+         */
+        keys(cb?: Callback<string[]>): string[];
+
+        /**
+         * get the stats
+         *
+         * @returns Stats data
+         */
+        getStats(): Stats;
+
+        /**
+         * flush the hole data and reset the stats
+         */
+        flushAll(): void;
+
+        /**
+         * This will clear the interval timeout which is set on checkperiod option.
+         */
+        close(): void;
+    }
+
+    export = NodeCache;
+}

--- a/sources/web/datalab/authentication.ts
+++ b/sources/web/datalab/authentication.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../../externs/ts/node/node.d.ts" />
+/// <reference path="../../../externs/ts/node/node-cache.d.ts" />
+/// <reference path="common.d.ts" />
+
+
+import http = require('http');
+import httpapi = require('./httpapi');
+import logging = require('./logging');
+import NodeCache = require("node-cache");
+
+/**
+ * The cache service for whitelisted user.
+ */
+var authCache: NodeCache = new NodeCache();
+
+/**
+ * The application settings instance.
+ */
+var appSettings: common.Settings;
+
+function getAccessTokenFromMetadataServer(cb: common.Callback<string>) {
+  var headers: common.Map<string> = {'X-Google-Metadata-Request': 'True'};
+  try {
+    httpapi.get(appSettings.metadataHost, '/computeMetadata/v1/instance/service-accounts/default/token',
+        null, null, headers, function(e: Error, data: any) {
+      if (e) {
+        logging.getLogger().error(e, 'Failed to get access token from metadata service.');
+        cb && cb(e, null);
+        return;
+      }
+      if (data && data.access_token) {
+        cb && cb(null, data.access_token);
+      }
+      else {
+        logging.getLogger().error('Failed to get access token metadata service response.');
+        cb && cb(Error('metadata server'), null);
+      }
+    });
+  }
+  catch (e) {
+    logging.getLogger().error(e, 'Failed to get access token from metadata service.');
+    cb && cb(e, null);
+  }
+}
+
+function lookupUserFromDatastore(userId: string, accessToken: string, cb: common.Callback<boolean>) {
+  var postData: any = {
+    keys: [
+      {
+        path: [
+          {
+            kind: 'DatalabUser',
+            name: userId
+          }
+        ]
+      }
+    ]
+  };
+  var dataStorePath: string = '/datastore/v1beta2/datasets/' + appSettings.projectId + '/lookup';
+  try {
+    httpapi.posts('www.googleapis.com', dataStorePath, null, postData, accessToken, null, function(e: Error, data: any) {
+      if (e) {
+        logging.getLogger().error(e, 'Failed to query Datastore for authentication.');
+        cb && cb(e, null);
+        return;
+      }
+      var found: boolean = data && data.found && data.found.length > 0;
+      if (found) {
+        // Add user to cache and set expiration to 10 mintutes.
+        authCache.set(userId, true, 600);
+      }
+      cb && cb(null, found);
+    });
+  } 
+  catch (e) {
+    logging.getLogger().error(e, 'Failed to query Datastore for authentication.');
+    cb && cb(e, null);
+  }
+}
+
+/**
+ * Checks whether a given user has access to this instance of Datalab.
+ */
+export function checkUserAccess(userId: string, cb: common.Callback<boolean>) {
+  if (authCache.get(userId)) {
+    process.nextTick(function() {
+      cb(null, true);
+    });
+    return;
+  }
+  getAccessTokenFromMetadataServer(function(e: Error, accessToken: string) {
+    if (e) {
+      cb && cb(e, false);
+      return;
+    }
+    lookupUserFromDatastore(userId, accessToken, cb);
+  });
+}
+
+/**
+ * Get the authentication URL where users sign in.
+ */
+export function getAuthenticationUrl(request: http.ServerRequest): string {
+  var authUrl: string = "https://datalab.cloud.google.com?startinproject="
+            + appSettings.projectId + "&name=" + appSettings.instanceName;
+  if (request.headers && request.headers.host) {
+    // If we get the host of the request, we can reconstruct the URL current user is requesting.
+    // Sending the URL to the launcher (deployer), so that it can go directly to the requested
+    // page after signin. It also makes local run working (otherwise, the launcher will not
+    // redirect user back to 127.0.0.1).
+    // Using http for local run, while in cloud http will be redirected to https.
+    authUrl += "&redirect=" + encodeURIComponent("http://" + request.headers.host + request.url)
+  }
+  return authUrl;
+}
+
+export function init(settings: common.Settings) : void {
+  appSettings = settings;
+}

--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -71,6 +71,13 @@ declare module common {
      * Useful when debugging multi-user functionality locally.
      */
     supportUserOverride: boolean;
+
+    /**
+     * Metadata host name. If specified, will override the default
+     * metadata host in AppEngine VM, mostly for local run so that
+     * the service account access token will be available locally.
+     */
+    metadataHost: string;
   }
 
   interface Map<T> {

--- a/sources/web/datalab/httpapi.ts
+++ b/sources/web/datalab/httpapi.ts
@@ -47,7 +47,7 @@ export function gets(host: string, path: string, args: common.Map<any>,
 export function post(host: string, path: string, args: common.Map<any>, data: Object,
                      token: string, headers: common.Map<string>,
                      callback: common.Callback<any>) {
-  request(host, HTTP_PORT, 'POST', path, args, null, token, headers, callback);
+  request(host, HTTP_PORT, 'POST', path, args, data, token, headers, callback);
 }
 
 /**
@@ -56,7 +56,7 @@ export function post(host: string, path: string, args: common.Map<any>, data: Ob
 export function posts(host: string, path: string, args: common.Map<any>, data: Object,
                       token: string, headers: common.Map<string>,
                       callback: common.Callback<any>) {
-  request(host, HTTPS_PORT, 'POST', path, args, null, token, headers, callback);
+  request(host, HTTPS_PORT, 'POST', path, args, data, token, headers, callback);
 }
 
 /**
@@ -81,7 +81,7 @@ function request(host: string, port: number, method: string, path: string,
     headers['Content-Length'] = requestBody.length.toString();
   }
   if (token) {
-    headers['Authorization'] = 'Bearer ' + token
+    headers['Authorization'] = 'Bearer ' + token;
   }
 
   var options: any = {
@@ -93,7 +93,7 @@ function request(host: string, port: number, method: string, path: string,
   };
 
   function requestCallback(response: http.ClientResponse) {
-    if (response.statusCode != 200) {
+    if (response.statusCode > 300) {
       var error = util.format('Failed %s %s%s: %d', method, host, path, response.statusCode);
       callback(new Error(error), null);
     }
@@ -105,7 +105,15 @@ function request(host: string, port: number, method: string, path: string,
       data += chunk;
     });
     response.on('end', function() {
-      callback(null, JSON.parse(data));
+      var obj: Object = null;
+      try {
+        obj = JSON.parse(data)
+      }
+      catch (e) {
+        callback(e, null);
+        return;
+      }
+      callback(null, obj);
     });
   }
 

--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -8,7 +8,8 @@
     "node-uuid": "^1.4.1",
     "socket.io": "^1.3.6",
     "tcp-port-used": "^0.1.2",
-    "ws": "^0.4.32"
+    "ws": "^0.4.32",
+    "node-cache": "~3.0.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -15,6 +15,7 @@
 /// <reference path="../../../externs/ts/node/node.d.ts" />
 /// <reference path="common.d.ts" />
 
+import auth = require('./authentication');
 import fs = require('fs');
 import health = require('./health');
 import http = require('http');
@@ -106,42 +107,19 @@ function handleJupyterRequest(request: http.ServerRequest, response: http.Server
 }
 
 /**
- * Handles all requests sent to the proxy web server. Some requests are handled within
- * the server, while some are proxied to the Jupyter notebook server.
+ * Handles all requests after being authenticated.
  * @param request the incoming HTTP request.
  * @param response the out-going HTTP response.
+ * @path the parsed path in the request.
  */
-function requestHandler(request: http.ServerRequest, response: http.ServerResponse) {
-  var path = url.parse(request.url).pathname;
-
-  // /_ah/* paths implement the AppEngine health check.
-  if (path.indexOf('/_ah') == 0) {
-    healthHandler(request, response);
-    return;
-  }
-
+function handledAuthenticatedRequest(request: http.ServerRequest,
+                                     response: http.ServerResponse,
+                                     path: string) {
   // TODO(jupyter): Additional custom path - should go away eventually with replaced
   // pages.
   // /static and /custom paths for returning static content
   if ((path.indexOf('/static') == 0) || (path.indexOf('/custom') == 0)) {
     staticHandler(request, response);
-    return;
-  }
-
-  // /ping allows the deployer to validate existence.
-  if (path.indexOf('/ping') == 0) {
-    // TODO: Remove support for CORS once the existence checks move to the deployment server.
-    response.writeHead(200, {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
-    });
-
-    // Respond with an object to singal availability and identity.
-    var pingResponse = {
-      name: appSettings.instanceName,
-      id: appSettings.instanceId
-    };
-    response.end(JSON.stringify(pingResponse));
     return;
   }
 
@@ -196,6 +174,57 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
 }
 
 /**
+ * Handles all requests sent to the proxy web server. Some requests are handled within
+ * the server, while some are proxied to the Jupyter notebook server.
+ * @param request the incoming HTTP request.
+ * @param response the out-going HTTP response.
+ */
+function requestHandler(request: http.ServerRequest, response: http.ServerResponse) {
+  var path = url.parse(request.url).pathname;
+
+  // /_ah/* paths implement the AppEngine health check.
+  if (path.indexOf('/_ah') == 0) {
+    healthHandler(request, response);
+    return;
+  }
+
+  // /ping allows the deployer to validate existence.
+  if (path.indexOf('/ping') == 0) {
+    // TODO: Remove support for CORS once the existence checks move to the deployment server.
+    response.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*'
+    });
+
+    // Respond with an object to singal availability and identity.
+    var pingResponse = {
+      name: appSettings.instanceName,
+      id: appSettings.instanceId
+    };
+    response.end(JSON.stringify(pingResponse));
+    return;
+  }
+
+  // Check if user has access.
+  var userId = userManager.getUserId(request);
+  auth.checkUserAccess(userId, function(e, hasAccess) {
+    if (e) {
+      response.statusCode = 500;
+      response.end("Authentication failure.");
+      return;
+    }
+    if (hasAccess) {
+      handledAuthenticatedRequest(request, response, path);
+    }
+    else {
+      response.statusCode = 302;
+      response.setHeader('Location', auth.getAuthenticationUrl(request));
+      response.end();
+    }
+  });  
+}
+
+/**
  * Runs the proxy web server.
  * @param settings the configuration settings to use.
  */
@@ -204,6 +233,7 @@ export function run(settings: common.Settings): void {
   userManager.init(settings);
   workspaceManager.init(settings);
   jupyter.init(settings);
+  auth.init(settings);
 
   healthHandler = health.createHandler(settings);
   infoHandler = info.createHandler(settings);

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -63,6 +63,7 @@ export function loadSettings(): common.Settings {
     settings.projectId = process.env['DATALAB_PROJECT_ID'] || '';
     settings.projectNumber = process.env['DATALAB_PROJECT_NUM'] || '';
     settings.versionId = process.env['DATALAB_VERSION'] || '';
+    settings.metadataHost = process.env['METADATA_HOST'] || 'metadata.google.internal';
     if (!settings.analyticsId) {
       settings.analyticsId = process.env['DATALAB_ANALYTICS_ID'] || '';
     }


### PR DESCRIPTION
Sorry that I deleted the branch and recreated it, so previous comments are lost from here. Below I will copy/paste them and add mine.

nikhil's comments
====================================
In containers/datalab/Dockerfile.in:

> @@ -97,7 +97,8 @@ RUN mkdir -p /datalab/web && \
>          node-uuid@1.4.3 \
>          bunyan@1.4.0 \
>          socket.io@1.3.6 \
> -        tcp-port-used@0.1.2 && \
> +        tcp-port-used@0.1.2 \
> +        googleapis@2.1.3 && \
Does this stuff really help over just manually crafting JSON and issuing HTTP requests. Whenever I look at this, I get the feeling these simple wrappers bring in tons of dependencies ... which have some impact on the disk size, but more importantly bloat into the node process space.

In sources/web/datalab/authentication.ts:

> +
> +/**
> + * The datastore service used to query Datastore to see if a user is allowed to access.
> + */
> +var datastore : any;
> +
> +/**
> + * The authentication Url that it will redirect users to if needed.
> + */
> +var authUrl: string;
> +
> +/**
> + * Checks whether a given user has access to this instance of Datalab.
> + */
> +export function checkUserAccess(userId: string, cb: common.Callback<boolean>) {
> +  datastore.datasets.lookup(
I imagine this is the one thing we do with datastore here - I'd prefer just using vanilla HTTP client, rather than the datastore wrapper.

In sources/web/datalab/server.ts:

> @@ -209,12 +238,18 @@ export function run(settings: common.Settings): void {
>    infoHandler = info.createHandler(settings);
>    staticHandler = static.createHandler(settings);
>  
> -  server = http.createServer(requestHandler);
Hopefully the changes in this file are not needed, once we get rid of the initialization of a datastore wrapper.

In sources/web/datalab/authentication.ts:

> +    }
> +  );
> +}
> +
> +/**
> + * Checks whether a given user has access to this instance of Datalab.
> + */
> +export function getAuthenticationUrl(): string {
> +  return authUrl;
> +}
> +
> +export function init(settings: common.Settings, cb: common.Callback0) : void {
> +  authUrl = "https://datalab.cloud.google.com?startinproject="
> +            + settings.projectId + "&name=" + settings.instanceName;
> +
> +  var compute = new googleapis.auth.Compute();
I am not sure how this works, but the token we get from here will expire in an hour, and the datastore wrapper created with it will no longer be usable after that.

Anyway, I think we do not need to create a datastore wrapper if we simply send the appropriate HTTP request. And effectively request the access token each time, so we get a valid token. The metadata service takes care of refreshing as needed.

qimingj's comments
================================
The calling of Datastore lookup API requires some crafting... Also the library handles token automatically (good catch on the token expiration bug), and that's the main reasons why the lib was introduced. Agree with your point that we could make it lighter without the lib. Done.

nikhil's comments
================================
In sources/web/datalab/authentication.ts:

> +var googleapis = require('googleapis');
> +
> +/**
> + * The datastore service used to query Datastore to see if a user is allowed to access.
> + */
> +var datastore : any;
> +
> +/**
> + * The authentication Url that it will redirect users to if needed.
> + */
> +var authUrl: string;
> +
> +/**
> + * Checks whether a given user has access to this instance of Datalab.
> + */
> +export function checkUserAccess(userId: string, cb: common.Callback<boolean>) {
We should cache this for some duration - eg. 1hr.

Repeated calls to datastore are expensive - perf/latency-wise, as well as cost wise.

qimingj's comments
================================
Done.