### PR TITLE
workspace update --- use new version of wsync

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -70,7 +70,7 @@ RUN pip install -U \
 # Setup Workspace-Sync
 RUN mkdir -p /wsync && \
     cd /wsync && \
-    wget -nv https://storage.googleapis.com/cloud-datalab/deploy/wsync/20150814/wsync && \
+    wget -nv https://storage.googleapis.com/cloud-datalab/deploy/wsync/20151118/wsync && \
     chmod u+r,g+x /wsync/* && cd /
 
 # Container configuration


### PR DESCRIPTION
wsync 0.4.0 changes the following:

1. Support -username and -email flags to avoid the "Rand Om Hacker" name show up in Dev console.
2. Require a workspace name appended in "wsync sync" command.
3. "-repo" needs to be replaced with "-workdir".

All the above were confirmed with wsync owner.