### PR TITLE
Add (back) MathJax support.

### DIFF
--- a/containers/datalab/config/ipython.py
+++ b/containers/datalab/config/ipython.py
@@ -29,3 +29,5 @@ c.InteractiveShellApp.exec_lines = []
 # Enable matplotlib renderings to show up inline in the notebook.
 c.InteractiveShellApp.matplotlib = 'inline'
 
+c.NotebookApp.mathjax_url = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
+

--- a/sources/web/datalab/config/settings.cloud.json
+++ b/sources/web/datalab/config/settings.cloud.json
@@ -15,7 +15,6 @@
     "notebook",
     "-y",
     "--no-browser",
-    "--no-mathjax",
     "--log-level=DEBUG",
     "--debug",
     "--NotebookApp.allow_origin=\"*\"",

--- a/sources/web/datalab/config/settings.debug.json
+++ b/sources/web/datalab/config/settings.debug.json
@@ -15,7 +15,6 @@
     "notebook",
     "-y",
     "--no-browser",
-    "--no-mathjax",
     "--log-level=DEBUG",
     "--debug",
     "--NotebookApp.allow_origin=\"*\"",

--- a/sources/web/datalab/config/settings.local.json
+++ b/sources/web/datalab/config/settings.local.json
@@ -16,7 +16,6 @@
     "notebook",
     "-y",
     "--no-browser",
-    "--no-mathjax",
     "--log-level=DEBUG",
     "--debug",
     "--NotebookApp.allow_origin=\"*\"",

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -9,6 +9,8 @@
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js?config=TeX-AMS_HTML-full,Safe&delayStartupUntil=configured" charset="utf-8"></script>
+
 </head>
 <body class="notebook_app"
   data-project=""
@@ -202,7 +204,7 @@
   <script src="/socket.io/socket.io.js"></script>
   <script src="/static/components/requirejs/require.js"></script>
   <script>
-    window.mathjax_url = '';
+    window.mathjax_url = "https://cdn.mathjax.org/mathjax/2.5-latest/MathJax.js";
     window.sys_info = {};
     require.config({
       baseUrl: '/static/',


### PR DESCRIPTION
We have had two customers request this so far via Google-Cloud-Datalab-Feedback@.

I looked at the size of the scripts that get downloaded due to this. While the
MathJax source is about 17MB, the minified scripts are not bad at all, coming in
at about 400kB.

I went for the CDN-hosted scripts as these may already be cached and may be faster
to retrieve than through hosting in the container. That said, I went for the the
2.5 release; we could instead just use 'latest' in the URL to get the latest
release which could improve likelihood of cached versions.

As far as the impact supporting MathJax could have on a new UX is concerned, it
can be estimated by looking at the impact on Jupyter, which is mostly in:

  https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/js/mathjaxutils.js

textcell.js and outputarea.js each have a few lines referencing this; most other
MathJax-related code in Jupyter (including some of mathjaxutils.js) is related just
to MathJax-related config (enabled or not, URL value, and handling load failure).

Issue #681