### PR TITLE
A simple alternative to widgets.

### DIFF
--- a/sources/lib/datalab/gcp/datalab/_chart.py
+++ b/sources/lib/datalab/gcp/datalab/_chart.py
@@ -17,6 +17,7 @@ import IPython
 import IPython.core.display
 import IPython.core.magic
 import gcp._util
+import gcp.data
 import _commands
 import _html
 import _utils
@@ -52,41 +53,161 @@ def _chart_cell(args, cell):
   chart_options = _utils.parse_config(cell, ipy.user_ns)
   if chart_options is None:
     chart_options = {}
+  elif not isinstance(chart_options, dict):
+    raise Exception("Could not parse chart options")
   fields = args['fields'] if args['fields'] else '*'
+  div_id = _html.Html.next_id()
+  env = {}
+  controls_html = ''
+  controls_ids = []
+  if 'variables' in chart_options:
+    variables = chart_options['variables']
+    del chart_options['variables']  # Just to make sure GCharts doesn't see them.
+    try:
+      item = _utils.get_notebook_item(source)
+      _, defaults = gcp.data.SqlModule.get_sql_statement_with_environment(item, '')
+    except Exception:
+      defaults = {}
+    for varname, control in variables.items():
+      label = control.get('label', varname)
+      control_id = div_id + '__' + varname
+      controls_ids.append(control_id)
+      value = control.get('value', defaults.get(varname, None))
+      # The user should usually specify the type but we will default to 'textbox' for strings
+      # and 'set' for lists.
+      if isinstance(value, basestring):
+        type = 'textbox'
+      elif isinstance(value, list):
+        type = 'set'
+      else:
+        type = None
+      type = control.get('type', type)
 
-  _HTML_TEMPLATE = u"""
-    <div class="bqgc" id="%s">
+      if type == 'picker':
+        choices = control.get('choices', value)
+        if not isinstance(choices, list) or len(choices) == 0:
+          raise Exception('picker control must specify a nonempty set of choices')
+        if value is None:
+          value = choices[0]
+        choices_html = ''
+        for i, choice in enumerate(choices):
+          choices_html += "<option value=\"%s\" %s>%s</option>" % \
+              (choice, ("selected=\"selected\"" if choice == value else ''), choice)
+        control_html = "{label}<select id=\"{id}\">{choices}</select>"\
+            .format(label=label, id=control_id, choices=choices_html)
+      elif type == 'set':  # Multi-picker; implemented as checkboxes.
+        # TODO(gram): consider using "name" property of the control to group checkboxes. That
+        # way we can save the code of constructing and parsing control Ids with sequential
+        #  numbers in it. Multiple checkboxes can share the same name.
+        choices = control.get('choices', value)
+        if not isinstance(choices, list) or len(choices) == 0:
+          raise Exception('set control must specify a nonempty set of choices')
+        if value is None:
+          value = choices
+        choices_html = ''
+        controls_ids[-1] = '%s:%d' % (control_id, len(choices))  # replace ID to include count.
+        for i, choice in enumerate(choices):
+          checked = choice in value
+          choice_id = '%s:%d' % (control_id, i)
+          # TODO(gram): we may want a 'Submit/Refresh button as we may not want to rerun
+          # query on each checkbox change.
+          choices_html += """
+            <div>
+              <label>
+                <input type="checkbox" id="{id}" value="{choice}" {checked}>
+                {choice}
+              </label>
+            </div>
+          """.format(id=choice_id, choice=choice, checked="checked" if checked else '')
+        control_html = "{label}<div>{choices}</div>".format(label=label, choices=choices_html)
+      elif type == 'checkbox':
+        control_html = """
+              <label>
+                <input type="checkbox" id="{id}" {checked}>
+                {label}
+              </label>
+          """.format(label=label, id=control_id, checked="checked" if value else '')
+      elif type == 'slider':
+        min = control.get('min', None)
+        max = control.get('max', None)
+        if min is None or max is None:
+          raise Exception('slider control must specify a min and max value')
+        if max <= min:
+          raise Exception('slider control must specify a min value less than max value')
+        step = control.get('step', 1 if isinstance(min, int) and isinstance(max, int)
+            else (max - min) / 10.0)
+        if value is None:
+          value = min
+        control_html = """
+          {label}
+          <input type="text" class="gchart-slider_value" id="{id}_value" value="{value}"/>
+          <input type="range" class="gchart-slider" id="{id}" min="{min}" max="{max}" step="{step}"
+              value="{value}"/>
+        """.format(label=label, id=control_id, value=value, min=min, max=max, step=step)
+      elif type == 'textbox':
+        if value is None:
+          value = ''
+        control_html = "{label}<input type=\"text\" value=\"{value}\" id=\"{id}\"/>"\
+            .format(label=label, value=value, id=control_id)
+      else:
+        raise Exception(
+            'Unknown control type %s (expected picker, slider, checkbox, textbox or set)' % type)
+
+      env[varname] = value
+      controls_html += "<div class=\"gchart-control\">{control}</div>\n"\
+          .format(control=control_html)
+
+    controls_html = "<div class=\"gchart-controls\">{controls}</div>".format(controls=controls_html)
+
+  _HTML_TEMPLATE = """
+    <div class="bqgc-container">
+      {controls}
+      <div class="bqgc{extra_class}" id="{id}">
+      </div>
     </div>
     <script>
-      require(['extensions/charting', 'element!%s', 'style!/static/extensions/charting.css'],
-        function(charts, dom) {
-          charts.render(dom, {chartStyle:'%s', dataName:'%s', fields:'%s'}, %s, %s);
-        }
+      require(['extensions/charting', 'element!{id}', 'style!/static/extensions/charting.css'],
+        function(charts, dom) {{
+          charts.render(dom, {{chartStyle:'{chart_type}', dataName:'{source}', fields:'{fields}'}},
+            {options}, {data}, {control_ids});
+        }}
       );
     </script>
   """
-  div_id = _html.Html.next_id()
+
   chart_type = args['chart']
   count = 25 if chart_type == 'paged_table' else -1
-  data, _ = _utils.get_data(source, fields, 0, count)
+  data, _ = _utils.get_data(source, fields, env, 0, count)
 
+  # TODO(gram): check if we need to augment env with user_ns
   return IPython.core.display.HTML(
-    _HTML_TEMPLATE % (div_id, div_id, chart_type, _utils.get_data_source_index(source), fields,
-                      json.dumps(chart_options, cls=gcp._util.JSONEncoder),
-                      json.dumps(data, cls=gcp._util.JSONEncoder)))
+    _HTML_TEMPLATE.format(controls=controls_html,
+                      id=div_id,
+                      chart_type=chart_type,
+                      extra_class=" bqgc-controlled" if len(controls_html) else '',
+                      source=_utils.get_data_source_index(source),
+                      fields=fields,
+                      options=json.dumps(chart_options, cls=gcp._util.JSONEncoder),
+                      data=json.dumps(data, cls=gcp._util.JSONEncoder),
+                      control_ids=str(controls_ids)))
 
 
-@IPython.core.magic.register_line_magic
-def _get_chart_data(line):
+@IPython.core.magic.register_cell_magic
+def _get_chart_data(line, cell_body=''):
   try:
     args = line.strip().split()
     source = _utils._data_sources[int(args[0])]
     fields = args[1]
     first_row = int(args[2]) if len(args) > 2 else 0
     count = int(args[3]) if len(args) > 3 else -1
-    data, _ = _utils.get_data(source, fields, first_row, count)
+    env = _utils.parse_config(cell_body, IPython.get_ipython().user_ns)
+    data, _ = _utils.get_data(source, fields, env, first_row, count)
   except Exception, e:
     gcp._util.print_exception_with_last_stack(e)
     data = {}
 
-  return IPython.core.display.JSON(json.dumps({'data': data}, cls=gcp._util.JSONEncoder))
+  # TODO(gram): The old way - commented out below - has the advantage that it worked
+  # for datetimes, but it is strictly wrong. The correct way below may have issues if the
+  # chart has datetimes though so test this.
+  return IPython.core.display.JSON({'data': data})
+  #return IPython.core.display.JSON(json.dumps({'data': data}, cls=gcp._util.JSONEncoder))

--- a/sources/lib/datalab/tests/bigquery_tests.py
+++ b/sources/lib/datalab/tests/bigquery_tests.py
@@ -34,7 +34,7 @@ import gcp.datalab
 
 class TestCases(unittest.TestCase):
 
-  @mock.patch('gcp.datalab._bigquery._notebook_environment')
+  @mock.patch('gcp.datalab._utils.notebook_environment')
   @mock.patch('gcp._context.Context.default')
   def test_udf_cell(self, mock_default_context, mock_notebook_environment):
     env = {}

--- a/sources/lib/datalab/tests/chart_tests.py
+++ b/sources/lib/datalab/tests/chart_tests.py
@@ -40,7 +40,7 @@ class TestCases(unittest.TestCase):
     self.assertTrue(chart.find('{"c": [{"v": "US"}, {"v": 100}]}') > 0)
     self.assertTrue(chart.find('{"c": [{"v": "ZA"}, {"v": 50}]}') > 0)
     self.assertTrue(chart.find('"cols": [{"type": "string", "id": "country", "label": "country"},' +
-                               ' {"type": "number", "id": "quantity", "label": "quantity"}]})') > 0)
+                               ' {"type": "number", "id": "quantity", "label": "quantity"}]}') > 0)
 
   @mock.patch('gcp._util.get_item')
   def test_get_chart_data(self, mock_get_item):
@@ -53,16 +53,16 @@ class TestCases(unittest.TestCase):
     mock_get_item.return_value = t
     ds = gcp.datalab._utils.get_data_source_index('t')
     data = gcp.datalab._chart._get_chart_data('%d country 1 1' % ds)
-    self.assertEquals('{"data": {"rows": [{"c": [{"v": "ZA"}]}], ' +
-                      '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
+    self.assertEquals({"data": {"rows": [{"c": [{"v": "ZA"}]}],
+                      "cols": [{"type": "string", "id": "country", "label": "country"}]}}, data)
 
     data = gcp.datalab._chart._get_chart_data('%d country 6 1' % ds)
-    self.assertEquals('{"data": {"rows": [], ' +
-                      '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
+    self.assertEquals({"data": {"rows": [],
+                      "cols": [{"type": "string", "id": "country", "label": "country"}]}}, data)
 
     data = gcp.datalab._chart._get_chart_data('%d country 2 0' % ds)
-    self.assertEquals('{"data": {"rows": [], ' +
-                      '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
+    self.assertEquals({"data": {"rows": [],
+                      "cols": [{"type": "string", "id": "country", "label": "country"}]}}, data)
 
   def test_chart_magic(self):
     # TODO(gram): complete this test

--- a/sources/web/datalab/static/extensions/charting.css
+++ b/sources/web/datalab/static/extensions/charting.css
@@ -44,3 +44,34 @@ th.gchart-table-headercell, table.dataframe th {
 div.bqgc img {
   max-width: none; // Fix the conflict with maps and Bootstrap that messes up zoom controls.
 }
+.gchart-slider {
+  width: 80%;
+  float: left;
+}
+.gchart-slider-value {
+  text-align: center;
+  float: left;
+  width: 20%;
+}
+.gchart-control {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+.gchart-controls {
+  font-size: 14px;
+  color: #333333;	 
+  background: #f4f4f4;
+  padding: 10px;
+  width: 180px;
+  float: left;
+}
+.bqgc {
+  padding: 0;
+  max-width: 100%;
+}
+.bqgc-controlled {
+  margin-left: 190px;
+}
+.bqgc-container {
+  display: block;
+}

--- a/sources/web/datalab/static/extensions/charting.js
+++ b/sources/web/datalab/static/extensions/charting.js
@@ -108,8 +108,8 @@ define("extensions/charting", function () {
     }
     model.firstRow = startRow;
     var dt = new model.visualization.DataTable({
-      'cols': model.data.cols,
-      'rows': model.data.rows.slice(startRow - model.dataOffset,
+      cols: model.data.cols,
+      rows: model.data.rows.slice(startRow - model.dataOffset,
           startRow - model.dataOffset + count)
     });
     model.chart.draw(dt, model.options);
@@ -138,8 +138,93 @@ define("extensions/charting", function () {
     if (count == 0) {
       return true;
     }
-    return startRow >= model.dataOffset &&
+    return model.data && startRow >= model.dataOffset &&
         (startRow + count) <= (model.dataOffset + model.data.rows.length);
+  }
+
+  // Iterate through any widget controls and build up a YAML representation
+  // of their values that can be passed to the Python kernel as part of the
+  // magic to fetch data (also used as part of the cache key).
+  function getControlEnvironment(model) {
+      var env = '';
+      if (model.controlIds) {
+        for (var i = 0; i < model.controlIds.length; i++) {
+          var id = model.controlIds[i];
+          var e = document.getElementById(id);
+          var parts = id.split('__');
+          var varname = parts[1];
+          var splitPoint = varname.indexOf(':');
+          if (splitPoint >= 0) { // this is a checkbox group
+            var count = parseInt(varname.substring(splitPoint + 1));
+            varname = varname.substring(0, splitPoint);
+            var cbBaseId = parts[0] + '__' + varname + ':';
+            env += varname + ': [';
+            var sep = '';
+            for (var j = 0; j < count; j++) {
+              var cb = document.getElementById(cbBaseId + j);
+              if (cb.checked) {
+                env += sep + cb.value;
+                sep = ',';
+              }
+            }
+            env += ']\n';
+          } else if (e && e.type == 'checkbox') {
+            // boolean
+            env += varname + ': ' + (e.checked ? 'on' : 'off') + '\n';
+          } else {
+            // picker/slider/text
+            env += varname + ': ' + e.value + '\n';
+          }
+        }
+      }
+      return env;
+  }
+
+  function update(model, newData, first, fetchCount, startRow) {
+    convertDates(newData.data);
+    model.data = newData.data;
+    if (model.chartStyle != 'paged_table') {
+      model.chart.draw(new model.visualization.DataTable(model.data), model.options);
+    }
+    else {
+      model.dataOffset = first;
+      // If we didn't know the data length before we do now if we got less than we asked for.
+      if (model.totalRows < 0) {
+        var len = model.data.rows.length;
+        if (len != fetchCount) {
+          model.totalRows = first + len;
+        }
+      }
+      // Calculate the number of rows we want to display.
+      var pageCount = getPageRowCount(model, startRow);
+      chartPage(model, startRow, pageCount);
+    }
+  }
+
+  function refresh(model, first, fetchCount, startRow) {
+    var env = getControlEnvironment(model);
+    var key = env + first + '/' + fetchCount;
+    if (model.cache[key]) {
+      update(model, model.cache[key], first, fetchCount, startRow);
+      return;
+    }
+    var code = model.fetchCode + ' ' + first + ' ' + fetchCount + '\n' + env;
+
+    // TODO: hook into the notebook UI to enable/disable 'Running...' while we
+    // fetch more data.
+    if (!model.cellElement) {
+      model.cellElement = getCell(model).element;
+    }
+    model.cellElement.removeClass('completed');
+    datalab.session.execute(code, function (error, newData) {
+      model.cellElement.addClass('completed');
+      if (error) {
+        onError(model.visualization, model.dom, error);
+      } else {
+        model.cache[key] = newData;
+        update(model, newData, first, fetchCount, startRow);
+      }
+    });
   }
 
   // Function to get a range of data and update chart with one page of data.
@@ -165,25 +250,7 @@ define("extensions/charting", function () {
         last = model.totalRows - 1;
       }
       var fetchCount = last - first + 1;
-      var code = model.fetchCode + ' ' + first + ' ' + fetchCount;
-
-      datalab.session.execute(code, function (error, newData) {
-        if (error) {
-          onError(model.visualization, model.dom, error);
-        } else {
-          convertDates(newData.data);
-          model.data = newData.data;
-          model.dataOffset = first;
-          // If we didn't know the data length before we do now if we got less than we asked for.
-          if (model.totalRows < 0) {
-            var len = model.data.rows.length;
-            if (len != fetchCount) {
-              model.totalRows = first + len;
-            }
-          }
-          chartPage(model, startRow, pageCount);
-        }
-      });
+      refresh(model, first, fetchCount, startRow);
     }
   }
 
@@ -253,7 +320,7 @@ define("extensions/charting", function () {
   // for the chart, model is a set of parameters from Python, and options is a JSON
   // set of options provided by the user in the cell magic body, which takes precedence over
   // model. An initial set of data can be passed in as a final optional parameter.
-  function render(dom, model, options, data) {
+  function render(dom, model, options, data, controlIds) {
     if (model.chartStyle == 'paged_table' && document._in_nbconverted) {
        model.chartStyle = 'table';
        var p = document.createElement("div");
@@ -269,8 +336,52 @@ define("extensions/charting", function () {
     }
     convertDates(data);
     model.dom = dom;
-
     removeStaticChart(model);  // Remove any existing chart PNG.
+
+    if (controlIds) {
+      var controlHandler = function() {
+        if (model.chartStyle == 'paged_table') {
+          model.totalRows = -1;
+          model.dataOffset = 0;
+          model.firstRow = 0;
+          model.data = undefined;
+          getPagedData(model, 0);
+        } else {
+          refresh(model, 0, -1, 0);
+        }
+      }
+      for (var i = 0; i < controlIds.length; i++) {
+        var id = controlIds[i];
+        var split = id.indexOf(':');
+        if (split >= 0) {
+          // Checkbox group.
+          var count = parseInt(id.substring(split + 1));
+          var base = id.substring(0, split + 1);
+          for (var j = 0; j < count; j++) {
+            document.getElementById(base + j).addEventListener('change', controlHandler);
+          }
+          continue;
+        }
+        // See if we have an associated control that needs dual binding.
+        var control = document.getElementById(id);
+        var textControl = document.getElementById(id + '_value');
+        if (textControl) {
+          textControl.addEventListener('change', function() {
+            if (control.value != textControl.value) {
+              control.value = textControl.value;
+              controlHandler();
+            }
+          });
+          control.addEventListener('change', function() {
+              textControl.value = control.value;
+              controlHandler();
+          });
+        } else {
+          control.addEventListener('change', controlHandler);
+        }
+      }
+    }
+
     require(['visualization!' + chartScript], function (visualization) {
       var chartType = visualization[chartInfo.name];
       var chart = new chartType(dom);
@@ -295,28 +406,31 @@ define("extensions/charting", function () {
         };
       }
 
-      if (model.chartStyle != 'paged_table') {
-        chart.draw(new visualization.DataTable(data), options);
-      }
-      else {
-        if (options.pageSize == undefined) {
-          options.pageSize = model.rowsPerPage || 25;
+      model.fetchCode = '%_get_chart_data ' + model.dataName + ' ' + (model.fields || '*');
+      model.controlIds = controlIds;
+      model.options = options;
+      model.data = data;
+      model.chart = chart;
+      model.dom = dom;
+      model.cache = {};
+      model.visualization = visualization;
+
+      if (model.chartStyle == 'paged_table') {
+        if (model.options.pageSize == undefined) {
+          model.options.pageSize = model.rowsPerPage || 25;
         }
-        model.chart = chart;
-        model.visualization = visualization;
-        model.fetchCode = '%_get_chart_data ' + model.dataName + ' ' + (model.fields || '*');
-        model.options = options;
         model.totalRows = model.totalRows || -1; // Total rows in all (server-side) data.
         model.dataOffset = 0; // Where the cached data[] array starts from.
         model.firstRow = 0;  // Index of first row being displayed in page.
-
-        model.data = data;
-
         visualization.events.addListener(chart, 'page', function(e) {
           handlePageEvent(model, e.page);
         });
-
         getPagedData(model, 0);
+      } else {
+        var env = getControlEnvironment(model);
+        var key = env + '0/-1';  // startRow and fetchCount for non-paged data.
+        model.cache[key] = {'data': model.data};
+        model.chart.draw(new model.visualization.DataTable(model.data), model.options);
       }
     });
   }


### PR DESCRIPTION
One of the complaints we have had from users is the lack of support for Jupyter widgets.
This change addresses some of that limitation by allowing the variables in %%sql modules
that are displayed with %%chart to include simple dynamic controls which will re-execute
the query with the new values when changed (with client-side caching of past results).

This is controlled via the YAML chart options, in a 'variables' section. There are five
types of controls supported, 'text' (textbox), 'set' (checkbox group), 'picker' (dropdown
allowing a single value), 'slider' (combined slider/textbox for numeric value with
min/max/step parameters), and 'boolean' (a checkbox for a Boolean value).

 Each can have an optional 'label' property that defaults to the variable name, and a
'value' property to set the initial value, which, if not present, defaults to the default
value in the %%sql cell. The control type is set by a 'type' property which will default to
'text' for strings and 'set' for lists but must otherwise be specified.

For sliders, if s 'step' property is not specified and 'min' and 'max' are ints a 'step' of
1 will be used; else a step of (max - min) / 10.0 will be used.

For pickers, if the variable is not a list, a list of values can be provided with the
'choices' property.

Some examples:

    %%sql -m mother_ages

    state=['WA', 'TX', 'AZ']

    SELECT mother_age, COUNT(*) AS count FROM [publicdata:samples.natality]
    WHERE state IN $state
    GROUP BY mother_age
    ORDER BY mother_age

    %chart paged_table -d mother_ages
    variables:
      state:
        label: 'State'

The above will create a set of three checkboxes which can be checked/unchecked in different
combinations to affect the resulting table via altering the IN clause of the query.

    %%sql -m total_for_age_by_state

    age=20

    SELECT state, COUNT(*) AS count FROM [publicdata:samples.natality]
    WHERE mother_age==$age
    GROUP BY state
    ORDER BY state

    %chart table -d total_for_age_by_state
    variables:
      age:
        type: slider
        min: 10
        max: 60

The above will create a slider to allow an age in the range 10 through 60 to be selected.

    %%sql -m total_by_state
    state = 'WA'
    married = True

    SELECT mother_age, COUNT(*) AS count FROM [publicdata:samples.natality]
    WHERE state==$state AND mother_married==$married
    GROUP BY mother_age
    ORDER BY mother_age

    %chart columns -d natality
    title: Births by Age and Marital Status of Mother
    hAxis:
      title: Age
    variables:
      state:
        type: picker
        choices: [AZ, TX, WA]
      married:
        type: boolean

The above will create both a picker for the three choices of state and a checkbox to toggle
the value of martial status.