### PR TITLE
Handle limited width browser experience better.

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -115,13 +115,14 @@ body {
 #mainToolbar, #sidebarToolbar {
   line-height: 48px;
   vertical-align: middle;
-  height: 48px;
+  min-height: 48px;
   color: #444;
   background-color: #f3f3f3;
   padding-left: 10px;
   padding-right: 10px;
   padding-top: 2px;
   border-bottom: solid 1px #e6e6e6;
+  overflow: auto;
 }
 #updateMessageArea {
   display: none;
@@ -129,7 +130,6 @@ body {
 }
 #mainContent, #sidebarContent {
   overflow: auto;
-  position: absolute;
   top: 48px;
   left: 0px;
   right: 0px;
@@ -138,6 +138,7 @@ body {
 #sidebarContent {
   color: #000;
   padding: 10px 20px;
+  position: absolute;
 }
 .container {
   min-width: 200px;


### PR DESCRIPTION
Change the CSS so that if the user has a browser of insufficient width we will
expand the toolbar to multiple lines as necessary instead of the toolbar items
disappearing.

Issue #713