### PR TITLE
Revert the CSS toolbar overflow changes.

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -115,14 +115,13 @@ body {
 #mainToolbar, #sidebarToolbar {
   line-height: 48px;
   vertical-align: middle;
-  min-height: 48px;
+  height: 48px;
   color: #444;
   background-color: #f3f3f3;
   padding-left: 10px;
   padding-right: 10px;
   padding-top: 2px;
   border-bottom: solid 1px #e6e6e6;
-  overflow: auto;
 }
 #updateMessageArea {
   display: none;
@@ -130,6 +129,7 @@ body {
 }
 #mainContent, #sidebarContent {
   overflow: auto;
+  position: absolute;
   top: 48px;
   left: 0px;
   right: 0px;
@@ -138,7 +138,6 @@ body {
 #sidebarContent {
   color: #000;
   padding: 10px 20px;
-  position: absolute;
 }
 .container {
   min-width: 200px;


### PR DESCRIPTION
I didn't notice when testing this that this results in a toolbar that can be scrolled
out of view if the notebook is longer than will fit in the browser window. That is
pretty undesirable behavior, so reverting for now and will investigate a different
fix.