### PR TITLE
CSV load fix

### DIFF
--- a/sources/lib/api/gcp/bigquery/_api.py
+++ b/sources/lib/api/gcp/bigquery/_api.py
@@ -102,22 +102,27 @@ class Api(object):
           'createDisposition': 'CREATE_IF_NEEDED' if create else 'CREATE_NEVER',
           'writeDisposition': write_disposition,
           'sourceFormat': source_format,
-          'fieldDelimiter': field_delimiter,
-          'allowJaggedRows': allow_jagged_rows,
-          'allowQuotedNewlines': allow_quoted_newlines,
-          'encoding': encoding,
           'ignoreUnknownValues': ignore_unknown_values,
           'maxBadRecords': max_bad_records,
-          'quote': quote,
-          'skipLeadingRows': skip_leading_rows
         }
       }
     }
+    if source_format == 'CSV':
+      load_config = data['configuration']['load']
+      load_config.update({
+        'fieldDelimiter': field_delimiter,
+        'allowJaggedRows': allow_jagged_rows,
+        'allowQuotedNewlines': allow_quoted_newlines,
+        'quote': quote,
+        'encoding': encoding,
+        'skipLeadingRows': skip_leading_rows
+      })
+
     return gcp._util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False, overwrite=False,
-                        dry_run=False, use_cache=True, batch=True, allow_large_results=False,
-                        table_definitions=None):
+  def jobs_insert_query(self, sql, code=None, imports=None, table_name=None, append=False,
+                        overwrite=False, dry_run=False, use_cache=True, batch=True,
+                        allow_large_results=False, table_definitions=None):
     """Issues a request to insert a query job.
 
     Args:

--- a/sources/lib/api/tests/bq_api_tests.py
+++ b/sources/lib/api/tests/bq_api_tests.py
@@ -77,8 +77,7 @@ class TestCases(unittest.TestCase):
     api.jobs_insert_load('SOURCE2', gcp.bigquery._utils.TableName('p2', 'd2', 't2', ''),
                          append=True, create=True, allow_jagged_rows=True,
                          allow_quoted_newlines=True, ignore_unknown_values=True,
-                         source_format='JSON', max_bad_records=1, skip_leading_rows=2,
-                         encoding='ASCII', quote="'")
+                         source_format='JSON', max_bad_records=1)
     expected_data = {
       'kind': 'bigquery#job',
       'configuration': {
@@ -92,14 +91,8 @@ class TestCases(unittest.TestCase):
           'createDisposition': 'CREATE_IF_NEEDED',
           'writeDisposition': 'WRITE_APPEND',
           'sourceFormat': 'JSON',
-          'fieldDelimiter': ',',
-          'allowJaggedRows': True,
-          'allowQuotedNewlines': True,
-          'encoding': 'ASCII',
           'ignoreUnknownValues': True,
-          'maxBadRecords': 1,
-          'quote': "'",
-          'skipLeadingRows': 2
+          'maxBadRecords': 1
         }
       }
     }


### PR DESCRIPTION
BQ is now rejecting Table loads of non-CSV files if CSV options are
specified. We would supply these regardless of the source format, so
this change only adds these arguments to the configuration if the
sourece format is CSV.

Issue #748