### PR TITLE
Use latest version of Google Cloud SDK instead of fixed version (0.9.57)

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -41,8 +41,6 @@ RUN wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \
     tools/google-cloud-sdk/install.sh --usage-reporting=false \
         --path-update=false --bash-completion=false \
         --disable-installation-options && \
-    tools/google-cloud-sdk/bin/gcloud config set --scope=installation \
-        component_manager/fixed_sdk_version 0.9.57 && \
     tools/google-cloud-sdk/bin/gcloud -q components update \
         gcloud core bq gsutil compute preview alpha beta && \
     rm -rf /root/.config/gcloud


### PR DESCRIPTION
PR to resolve issue #763. If accepted, I will also update the development wiki to `gcloud init` instead of `gcloud config set project 'myProject'`