### PR TITLE
Look for error.message in error responses.

### DIFF
--- a/sources/lib/api/gcp/_util/_http.py
+++ b/sources/lib/api/gcp/_util/_http.py
@@ -27,7 +27,10 @@ class RequestException(Exception):
     self.message = 'HTTP request failed'
     # Try extract a message from the body; swallow possible resulting ValueErrors and KeyErrors.
     try:
-      self.message = json.loads(content)['error']['errors'][0]['message']
+      error = json.loads(content)['error']
+      if 'errors' in error:
+          error = error['errors'][0]
+      self.message = error['message']
     except ValueError:
       pass
     except KeyError:


### PR DESCRIPTION
The code was looking for error.errors.0.message, but some APIs
(e.g., the Google Monitoring API) don't return error details under
error.errors, while error.message is generally supposed to be present.