### PR TITLE
include plotly

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -64,6 +64,7 @@ RUN pip install -U \
     pip install -U seaborn==0.6.0 && \
     pip install -U notebook==4.0.2 && \
     pip install -U PyYAML==3.11 && \
+    pip install -U plotly==1.9.6 && \
     easy_install pip && \
     find /usr/local/lib/python2.7 -type d -name tests | xargs rm -rf
 


### PR DESCRIPTION
Including plotly in the Dockerfile.
This allows users (and sample notebooks) to use the plotly library out of the box.