### PR TITLE
Make signing in to Google optional.

### DIFF
--- a/sources/lib/datalab/datalab/bigquery/commands/_bigquery.py
+++ b/sources/lib/datalab/datalab/bigquery/commands/_bigquery.py
@@ -610,12 +610,12 @@ def _schema_line(args):
 
 def _render_table(data, fields=None):
   """ Helper to render a list of dictionaries as an HTML display object. """
-  return IPython.core.display.HTML(_html.HtmlBuilder.render_table(data, fields))
+  return IPython.core.display.HTML(datalab.utils.commands.HtmlBuilder.render_table(data, fields))
 
 
 def _render_list(data):
   """ Helper to render a list of objects as an HTML list object. """
-  return IPython.core.display.HTML(_html.HtmlBuilder.render_list(data))
+  return IPython.core.display.HTML(datalab.utils.commands.HtmlBuilder.render_list(data))
 
 
 def _datasets_line(args):
@@ -913,7 +913,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
 
   if fields is None:
     fields = datalab.utils.commands.get_field_list(fields, table.schema)
-  div_id = _html.Html.next_id()
+  div_id = datalab.utils.commands.Html.next_id()
   meta_count = ('rows: %d' % table.length) if table.length >= 0 else ''
   meta_name = str(table) if table.job is None else ('job: %s' % table.job.id)
   if table.job:
@@ -941,7 +941,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
   meta_data = '(%s)' % (', '.join([entry for entry in meta_entries if len(entry)]))
 
   return _HTML_TEMPLATE.format(div_id=div_id,
-                               static_table=_html.HtmlBuilder.render_chart_data(data),
+                               static_table=datalab.utils.commands.HtmlBuilder.render_chart_data(data),
                                meta_data=meta_data,
                                chart_style=chart,
                                source_index=datalab.utils.commands.get_data_source_index(str(table)),
@@ -953,7 +953,7 @@ def _table_viewer(table, rows_per_page=25, fields=None):
 
 def _repr_html_query(query):
   # TODO(nikhilko): Pretty print the SQL
-  return _html.HtmlBuilder.render_text(query.sql, preformatted=True)
+  return datalab.utils.commands.HtmlBuilder.render_text(query.sql, preformatted=True)
 
 
 def _repr_html_query_results_table(results):
@@ -976,7 +976,7 @@ def _repr_html_table_schema(schema):
       );
     </script>
     """
-  id = _html.Html.next_id()
+  id = datalab.utils.commands.Html.next_id()
   return _HTML_TEMPLATE % (id, id, json.dumps(schema._bq_schema))
 
 

--- a/sources/lib/datalab/datalab/context/_utils.py
+++ b/sources/lib/datalab/datalab/context/_utils.py
@@ -17,6 +17,11 @@
 import oauth2client.client
 import json
 import os
+import path
+
+
+def _in_datalab_docker():
+  return path.exists('/datalab') and os.getenv('DATALAB_ENV')
 
 
 def get_config_dir():
@@ -56,5 +61,10 @@ def get_credentials():
       for entry in creds['data']:
         if entry['key']['type'] == 'google-cloud-sdk':
           return oauth2client.client.OAuth2Credentials.from_json(json.dumps(entry['credential']))
+
+    if type(e) == oauth2client.client.ApplicationDefaultCredentialsError:
+      # If we are in Datalab container, change the message to be about signing in.
+      if _in_datalab_docker():
+        raise Exception('No application credentials found. Perhaps you should sign in.')
 
     raise e

--- a/sources/lib/datalab/datalab/kernel/__init__.py
+++ b/sources/lib/datalab/datalab/kernel/__init__.py
@@ -83,7 +83,7 @@ def load_ipython_extension(shell):
     return _orig_run_line_magic(self, magic_name, line)
 
   def _run_cell_magic(self, magic_name, line, cell):
-    if cell.isspace():
+    if len(cell) == 0 or cell.isspace():
       fn = self.find_line_magic(magic_name)
       if fn:
         return _orig_run_line_magic(self, magic_name, line)

--- a/sources/lib/datalab/datalab/notebook/static/charting.ts
+++ b/sources/lib/datalab/datalab/notebook/static/charting.ts
@@ -427,7 +427,7 @@ module Charting {
         }
       } catch (e) {
       }
-      this.dom.innerHTML = '';
+      (<HTMLElement>this.dom).innerHTML = '';
       this.removeStaticChart();
       this.addControls();
       // Generate and add a new static chart once chart is ready.

--- a/sources/lib/datalab/datalab/storage/commands/_storage.py
+++ b/sources/lib/datalab/datalab/storage/commands/_storage.py
@@ -20,6 +20,7 @@ except ImportError:
   raise Exception('This module can only be loaded in ipython.')
 
 import fnmatch
+import json
 import re
 
 import datalab.storage

--- a/sources/lib/datalab/datalab/utils/_http.py
+++ b/sources/lib/datalab/datalab/utils/_http.py
@@ -17,6 +17,7 @@ import json
 import urllib
 import httplib2
 
+
 # TODO(nikhilko): Start using the requests library instead.
 
 

--- a/sources/lib/datalab/datalab/utils/_job.py
+++ b/sources/lib/datalab/datalab/utils/_job.py
@@ -160,7 +160,7 @@ class Job(object):
       try:
         self._result = self._future.result()
       except Exception as e:
-        message = e.message if e.message else e.strerror
+        message = e.message if e.message else str(e)
         self._fatal_error = JobError(location=traceback.format_exc(), message=message,
                                      reason=str(type(e)))
 

--- a/sources/lib/datalab/tests/kernel/bigquery_tests.py
+++ b/sources/lib/datalab/tests/kernel/bigquery_tests.py
@@ -16,7 +16,6 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
-import IPython.core
 import IPython.core.magic
 
 

--- a/sources/lib/datalab/tests/kernel/chart_data_tests.py
+++ b/sources/lib/datalab/tests/kernel/chart_data_tests.py
@@ -15,8 +15,8 @@ import mock
 import unittest
 
 # import Python so we can mock the parts we need to here.
-import IPython
-import IPython.core
+import IPython.core.display
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/chart_tests.py
+++ b/sources/lib/datalab/tests/kernel/chart_tests.py
@@ -13,8 +13,8 @@
 import unittest
 
 # import Python so we can mock the parts we need to here.
-import IPython
-import IPython.core
+import IPython.core.display
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/commands_tests.py
+++ b/sources/lib/datalab/tests/kernel/commands_tests.py
@@ -15,6 +15,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/html_tests.py
+++ b/sources/lib/datalab/tests/kernel/html_tests.py
@@ -15,7 +15,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
-import IPython.core
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/module_tests.py
+++ b/sources/lib/datalab/tests/kernel/module_tests.py
@@ -16,6 +16,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/sql_tests.py
+++ b/sources/lib/datalab/tests/kernel/sql_tests.py
@@ -17,7 +17,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
-import IPython.core
+import IPython.core.magic
 
 
 def noop_decorator(func):
@@ -28,6 +28,7 @@ IPython.core.magic.register_line_magic = noop_decorator
 IPython.core.magic.register_cell_magic = noop_decorator
 IPython.get_ipython = mock.Mock()
 
+import datalab.bigquery
 import datalab.context
 import datalab.data
 import datalab.data.commands

--- a/sources/lib/datalab/tests/kernel/storage_tests.py
+++ b/sources/lib/datalab/tests/kernel/storage_tests.py
@@ -16,7 +16,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
-import IPython.core
+import IPython.core.magic
 
 
 def noop_decorator(func):

--- a/sources/lib/datalab/tests/kernel/utils_tests.py
+++ b/sources/lib/datalab/tests/kernel/utils_tests.py
@@ -19,7 +19,7 @@ import unittest
 
 # import Python so we can mock the parts we need to here.
 import IPython
-import IPython.core
+import IPython.core.magic
 
 
 IPython.core.magic.register_line_cell_magic = mock.Mock()

--- a/sources/lib/datalab/tests/storage/bucket_tests.py
+++ b/sources/lib/datalab/tests/storage/bucket_tests.py
@@ -16,6 +16,7 @@ import unittest
 
 import datalab.context
 import datalab.storage
+import datalab.utils
 
 
 class TestCases(unittest.TestCase):

--- a/sources/lib/datalab/tests/storage/item_tests.py
+++ b/sources/lib/datalab/tests/storage/item_tests.py
@@ -16,6 +16,7 @@ import unittest
 
 import datalab.context
 import datalab.storage
+import datalab.utils
 
 
 class TestCases(unittest.TestCase):

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -17,6 +17,7 @@
 /// <reference path="../../../externs/ts/node/tcp-port-used.d.ts" />
 /// <reference path="common.d.ts" />
 
+import auth = require('./auth')
 import callbacks = require('./callbacks');
 import childProcess = require('child_process');
 import fs = require('fs');
@@ -297,6 +298,9 @@ function responseHandler(proxyResponse: http.ClientResponse,
     if (path.indexOf('/tree') == 0) {
       // stripping off the /tree/ from the path
       templateData['notebookPath'] = path.substr(6);
+      if (process.env.DATALAB_ENV == 'local') {
+        templateData['isSignedIn'] = auth.isSignedIn().toString();
+      }
 
       sendTemplate('tree', templateData, response);
       page = 'tree';

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -178,18 +178,17 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       response.writeHead (302, {'Location': referer})
     }
     response.end();
-    return;
-  }
-  if (!fs.existsSync(configFile)) {
+  } else if (path.indexOf('/signin') == 0 || path.indexOf('/signout') == 0 ||
+      path.indexOf('/oauthcallback') == 0) {
+    // Start or return from auth flow.
+    auth.handleAuthFlow(request, response, parsed_url, appSettings);
+  } else if (!fs.existsSync(configFile)) {
     logging.getLogger().info('No Datalab config; redirect to EULA page');
     fs.readFile('/datalab/web/static/eula.html', function(error, content) {
       response.writeHead(200);
       response.end(content);
     });
-    return;
-  }
-
-  if (auth.handleAuthFlow(request, response, parsed_url, appSettings)) {
+  } else {
     handleRequest(request, response, path);
   }
 }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -46,6 +46,20 @@ function initializePage(dialog) {
   $('#feedbackButton').click(function() {
     window.open('https://groups.google.com/forum/#!newtopic/google-cloud-datalab-feedback');
   });
+  var signedIn = document.body.getAttribute('data-signed-in');
+  if (signedIn != undefined) {  // i.e. running locally.
+    if (signedIn == "true") {
+      $('#signOutButton').show();
+    } else {
+      $('#signInButton').show();
+    }
+    $('#signInButton').click(function() {
+      window.location = '/signin?referer=' + encodeURIComponent(window.location);
+    });
+    $('#signOutButton').click(function() {
+      window.location = '/signout?referer=' + encodeURIComponent(window.location);
+    });
+  }
 }
 
 function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -16,6 +16,7 @@
   data-terminals-available="False"
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
+  data-signed-in="<%isSignedIn%>"
   data-user-id="<%userId%>">
 
   <div id="app">
@@ -40,6 +41,16 @@
               <span class="fa fa-book"></span>
             </button>
           </a>
+        </div>
+        <div class="btn-group">
+          <button id="signInButton" title="Sign In" style="display:none">
+            <span class="fa fa-sign-in"></span>
+          </button>
+        </div>
+        <div class="btn-group">
+          <button id="signOutButton" title="Sign Out" style="display:none">
+            <span class="fa fa-sign-out"></span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added a sign in button to the tree view instead of forcing auth on first request. Users can now use Datalab without signing in to Google (but signing in is needed before any GCP stuff can be used).

We probably want to change the button/icon to make it more obvious but at least the functionality
is there.

Fixed a couple of regressions that came in the big refactoring change before.

Fixed a bunch of imports in tests.

Folded in PR https://github.com/GoogleCloudPlatform/datalab/pull/815 as it was easier to do this one liner here than try to merge it with all the other changes.