### PR TITLE
Add ability to create and run a customized image derived from the datalab image

### DIFF
--- a/containers/datalab/Dockerfile-extended-example.in
+++ b/containers/datalab/Dockerfile-extended-example.in
@@ -1,0 +1,7 @@
+# Use this file to create a new docker image derived from the standard datalab image
+
+FROM gcr.io/cloud-datalab/datalab:latest
+#MAINTAINER Your Name <youremail@example.com>
+
+# The following line will install package xlrd, as an example
+RUN pip install xlrd

--- a/containers/datalab/custom-packages-example.txt
+++ b/containers/datalab/custom-packages-example.txt
@@ -1,0 +1,4 @@
+# Use this file to add additional python packages to datalab
+
+# The following line will install package xlrd, as an example
+xlrd

--- a/containers/datalab/run-extended.sh
+++ b/containers/datalab/run-extended.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the docker container locally. Auth will happen in the browser when
+# the user first opens Datalab after accepting the EULA.
+
+# Passing in 'shell' flag causes the docker container to break into a
+# command prompt, which is useful for tinkering within the container before
+# manually starting the server.
+
+CONTENT=$HOME
+DOCKERIMAGE=datalab
+ENTRYPOINT="/datalab/run.sh"
+if [ "$1" != "" ]; then
+  if [ "$1" != "shell" ]; then
+    CONTENT=$1
+    shift
+  fi
+  if [ "$1" == "shell" ]; then
+    ENTRYPOINT="/bin/bash"
+  fi
+fi
+
+# Custom packages can be installed in datalab prior to run time. There are 2 options
+# available. A simple option is to add the packages to a pip requirements file. Create a file
+# called 'custom-packages.txt' and place it in the $REPO_DIR/containers/datalab folder. Use
+# 'custom-packages-example.txt' as a starting point. Another option is to create a Dockerfile
+# called 'Dockerfile-extended.in' and place it in the $REPO_DIR/containers/datalab folder.
+# Use 'Dockerfile-extended-example.in' as a starting point. In both cases, a customized
+# docker image will be created which is derived from the standard datalab image.
+if [ -f custom-packages.txt ] || [ -f Dockerfile-extended.in ];
+then
+    if [ -f custom-packages.txt ];
+    then
+        # First create a new Docker file called Dockerfile-custom-packages. Start with the standard image
+        echo 'FROM gcr.io/cloud-datalab/datalab:latest' > Dockerfile-custom-packages
+
+        # Add the script with a list of custom packages to the Dockerfile
+        echo 'ADD custom-packages.txt /datalab/custom-packages.txt' >> Dockerfile-custom-packages
+        echo 'RUN pip install -r /datalab/custom-packages.txt' >> Dockerfile-custom-packages
+
+        DOCKERFILE=Dockerfile-custom-packages
+        DOCKERIMAGE=datalab-custom-packages
+
+    elif [ -f Dockerfile-extended.in ];
+    then
+        DOCKERFILE=Dockerfile-extended.in
+        DOCKERIMAGE=datalab-extended
+    fi
+
+    # Build the customized docker image derived from the standard datalab image
+    docker build -t $DOCKERIMAGE -f $DOCKERFILE .
+
+    # TODO (Tony): Remove this line when gcr.io/cloud-datalab/datalab:latest is updated to a newer version that has /datalab/run.sh
+    ENTRYPOINT="/datalab/run-local.sh"
+fi
+
+# Use this flag to map in web server content during development
+#  -v $REPO_DIR/sources/web:/sources \
+
+docker run -it --entrypoint=$ENTRYPOINT \
+  -p 8081:8080 \
+  -v "$CONTENT:/content" \
+  -e "PROJECT_ID=$PROJECT_ID" \
+  -e "DATALAB_ENV=local" \
+  $DOCKERIMAGE


### PR DESCRIPTION
A first implementation to enable installation of custom python packages as part of the datalab image build script as described in #826 . 

If the file `'custompackages.txt'` exists in `'$REPO_DIR/containers/datalab'`, then install the python packages listed in the file.

Here is an example of the contents of custompackages.txt:

```
xlrd
```

We could easily modify this PR to also append a command that executes a more flexible install script (*.sh) to the Dockerfile, if the *.sh script exists.

Feedback is welcome.