### PR TITLE
Fix a build failure that was triggered by `cp` skipping a directory.

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -129,7 +129,7 @@ RUN ipython profile create default && \
     cd /datalab/lib/datalab-0.1.* && pip install . && \
     jupyter nbextension install --py datalab.notebook && \
     mkdir -p /datalab/nbconvert && \
-    cp /usr/local/share/jupyter/nbextensions/gcpdatalab/* /datalab/nbconvert && \
+    cp -R /usr/local/share/jupyter/nbextensions/gcpdatalab/* /datalab/nbconvert && \
     ln -s /usr/local/lib/python2.7/dist-packages/notebook/static/custom/custom.css /datalab/nbconvert/custom.css && \
     ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css&& \
     mkdir -p /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/sql/text && \


### PR DESCRIPTION
The command that does a wildcard copy of files into the nbconvert
directory needs to include the contents of the `codemirror`
subdirectory. Failing to include the "-R" flag was causing that
copy to fail with an error message that the subdirectory was being
ignored.

This change fixes that by adding the required "-R" flag.