### PR TITLE
Set the min-width of the HTML body tag to be the smallest we support.

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -25,6 +25,7 @@ body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
   background: #fff;
+  min-width: 1200px;
 }
 
 /* Layout */


### PR DESCRIPTION
The nav-bar in the datalab UI does not layout cleanly if the width of
the page is less than ~1200 pixels. It would require quite a bit of
work to make the UI scale down to smaller than that size (e.g. by
switching the nav-bar to be a drop-down menu), so as a work-around
we will set the min-width of the body to be the smallest window
size we currently support.

With this change, if a user opens datalab in a browser window that
is smaller than our min-width, then the browser will render the
page at the min width, and will show the user a scroll bar to
move the window over that page.

This fixes (or, at least, mitigates) #713