### PR TITLE
Fix a bug in the 'Convert to Python' functionality.

### DIFF
--- a/containers/datalab/config/nbconvert.py
+++ b/containers/datalab/config/nbconvert.py
@@ -16,4 +16,4 @@
 
 c = get_config()
 c.TemplateExporter.template_path.insert(0, '/datalab/nbconvert')
-c.TemplateExporter.template_file = 'html'
+c.HTMLExporter.template_file = 'html'


### PR DESCRIPTION
The issue was that when you tried to convert a notebook to python,
the server returned a cryptic error message with the name of the
default HTML template.

The root cause was that when we set the 'template_file' config
variable for exporting to HTML, we did so for *every* exporter,
and not just the HTMLExporter.

This change fixes that by only setting that config variable on
the HTMLExporter.