### PR TITLE
Add the sign-in/sign-out buttons to the notebooks UI.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -293,14 +293,14 @@ function responseHandler(proxyResponse: http.ClientResponse,
       configUrl: appSettings.configUrl,
       baseUrl: '/'
     };
+    if (process.env.DATALAB_ENV == 'local') {
+      templateData['isSignedIn'] = auth.isSignedIn().toString();
+    }
 
     var page: string = null;
     if (path.indexOf('/tree') == 0) {
       // stripping off the /tree/ from the path
       templateData['notebookPath'] = path.substr(6);
-      if (process.env.DATALAB_ENV == 'local') {
-        templateData['isSignedIn'] = auth.isSignedIn().toString();
-      }
 
       sendTemplate('tree', templateData, response);
       page = 'tree';

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -18,6 +18,7 @@
   data-notebook-path="<%notebookPath%>"
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
+  data-signed-in="<%isSignedIn%>"
   data-user-id="<%userId%>">
   <div id="app">
     <div id="appBar">
@@ -62,6 +63,16 @@
               <span class="fa fa-book"></span>
             </button>
           </a>
+        </div>
+        <div class="btn-group">
+          <button id="signInButton" title="Sign In" style="display:none">
+            <span class="fa fa-sign-in"></span>
+          </button>
+        </div>
+        <div class="btn-group">
+          <button id="signOutButton" title="Sign Out" style="display:none">
+            <span class="fa fa-sign-out"></span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
There are some sample notebooks which require credentials to run
(because they call into external APIs). If you try to run those
notebooks while signed out, then they will produce an error
message helpfully suggesting that you sign.

However, the sign-in button was only being shown on the tree-view
page and not on the notebook-view page.

This meant that you had to navigate back to the tree-view page,
sign in, and then go back to the notebook to retry running the
code.

This change fixes that by adding the sign-in/sign-out buttons
to the notebook-view page in the exact same place they appear
for the tree-view page.