### PR TITLE
Add a new template for the file editing page.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -55,6 +55,7 @@ var callbackManager: callbacks.CallbackManager = new callbacks.CallbackManager()
  */
 var templates: common.Map<string> = {
   'tree': fs.readFileSync(path.join(__dirname, 'templates', 'tree.html'), { encoding: 'utf8' }),
+  'edit': fs.readFileSync(path.join(__dirname, 'templates', 'edit.html'), { encoding: 'utf8' }),
   'nb': fs.readFileSync(path.join(__dirname, 'templates', 'nb.html'), { encoding: 'utf8' })
 };
 
@@ -285,7 +286,7 @@ function responseHandler(proxyResponse: http.ClientResponse,
   // Set a cookie to provide information about the project and authenticated user to the client.
   // Ensure this happens only for page requests, rather than for API requests.
   var path = url.parse(request.url).pathname;
-  if ((path.indexOf('/tree') == 0) || (path.indexOf('/notebooks') == 0)) {
+  if ((path.indexOf('/tree') == 0) || (path.indexOf('/notebooks') == 0) || (path.indexOf('/edit') == 0)) {
     var templateData: common.Map<string> = {
       feedbackId: appSettings.feedbackId,
       versionId: appSettings.versionId,
@@ -304,8 +305,14 @@ function responseHandler(proxyResponse: http.ClientResponse,
 
       sendTemplate('tree', templateData, response);
       page = 'tree';
-    }
-    else {
+    } else if (path.indexOf('/edit') == 0) {
+      // stripping off the /edit/ from the path
+      templateData['filePath'] = path.substr(6);
+      templateData['fileName'] = path.substr(path.lastIndexOf('/') + 1);
+
+      sendTemplate('edit', templateData, response);
+      page = 'edit';
+    } else {
       // stripping off the /notebooks/ from the path
       templateData['notebookPath'] = path.substr(11);
       templateData['notebookName'] = path.substr(path.lastIndexOf('/') + 1);

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -303,23 +303,21 @@ function responseHandler(proxyResponse: http.ClientResponse,
       // stripping off the /tree/ from the path
       templateData['notebookPath'] = path.substr(6);
 
-      sendTemplate('tree', templateData, response);
       page = 'tree';
     } else if (path.indexOf('/edit') == 0) {
       // stripping off the /edit/ from the path
       templateData['filePath'] = path.substr(6);
       templateData['fileName'] = path.substr(path.lastIndexOf('/') + 1);
 
-      sendTemplate('edit', templateData, response);
       page = 'edit';
     } else {
       // stripping off the /notebooks/ from the path
       templateData['notebookPath'] = path.substr(11);
       templateData['notebookName'] = path.substr(path.lastIndexOf('/') + 1);
 
-      sendTemplate('nb', templateData, response);
       page = 'notebook';
     }
+    sendTemplate(page, templateData, response);
 
     // Suppress further writing to the response to prevent sending response
     // from the notebook server. There is no way to communicate that, so hack around the

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -166,6 +166,14 @@ body {
   right: 0px;
   bottom: 0px;
 }
+.fileMainContent {
+  overflow: auto;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+}
 .treeMainContent {
   overflow: auto;
   position: absolute;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -717,6 +717,9 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
 function initializeEditApplication(ipy, editor) {
   function navigateAlternate(alt) {
     var url = document.location.href.replace('/edit', alt);
+    if (url.includes("?")) {
+      url = url.slice(0, url.lastIndexOf("?"));
+    }
     url = url + '?download=true';
 
     if (!editor.clean) {

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -714,6 +714,36 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
 }
 
 
+function initializeEditApplication(ipy, editor) {
+  function navigateAlternate(alt) {
+    var url = document.location.href.replace('/edit', alt);
+    url = url + '?download=true';
+
+    if (!editor.clean) {
+      var w = window.open('');
+      editor.save().then(function() {
+        window.open(url);
+      });
+    }
+    else {
+      window.open(url);
+    }
+  }
+
+  $('#saveButton').click(function() {
+    editor.save();
+  })
+
+  $('#renameButton').click(function() {
+    notebook.save_widget.rename();
+  })
+
+  $('#downloadButton').click(function() {
+    navigateAlternate('/files');
+  })
+}
+
+
 function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, utils) {
   function showContent(e) {
     document.getElementById('notebooks').classList.add('active');
@@ -849,6 +879,9 @@ function initializeDataLab(ipy, events, dialog, utils, security) {
   var pageClass = document.body.className;
   if (pageClass.indexOf('notebook_app') >= 0) {
     initializeNotebookApplication(ipy, ipy.notebook, events, dialog, utils);
+  }
+  else if (pageClass.indexOf('edit_app') >= 0) {
+    initializeEditApplication(ipy, ipy.editor);
   }
   else if (pageClass.indexOf('notebook_list') >= 0) {
     initializeNotebookList(ipy, ipy.notebook_list, ipy.new_notebook_widget, events, dialog, utils);

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -720,7 +720,6 @@ function initializeEditApplication(ipy, editor) {
     url = url + '?download=true';
 
     if (!editor.clean) {
-      var w = window.open('');
       editor.save().then(function() {
         window.open(url);
       });

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+
+  <title>Google Cloud DataLab</title>
+  <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
+  <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+</head>
+<body class="edit_app"
+  data-project=""
+  data-base-url="/"
+  data-ws-url=""
+  data-file-name="<%fileName%>"
+  data-file-path="<%filePath%>"
+  data-feedback-id="<%feedbackId%>"
+  data-version-id="<%versionId%>"
+  data-signed-in="<%isSignedIn%>"
+  data-user-id="<%userId%>">
+  <div id="app">
+    <div id="appBar">
+      <span id="logo" class="nav navbar-brand pull-left">
+        <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
+      </span>
+      <span id="save_widget" class="pull-left save_widget">
+        <button class="btn" title="Rename file"><span id="file_name" class="filename"></span></button>
+        <span class="autosave_status"></span>
+      </span>
+      <div class="btn-toolbar pull-right">
+        <div class="btn-group">
+          <button id="feedbackButton" title="Provide feedback">
+            <span class="fa fa-comment"></span>
+          </button>
+        </div>
+        <div class="btn-group">
+          <button id="aboutButton" title="About Google Cloud Datalab">
+            <span class="fa fa-info-circle"></span>
+          </button>
+        </div>
+        <div class="btn-group">
+          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton" class="btn">
+            <button id="docsButton" title="Samples and Tutorials">
+              <span class="fa fa-book"></span>
+            </button>
+          </a>
+        </div>
+        <div class="btn-group">
+          <button id="signInButton" title="Sign In" style="display:none">
+            <span class="fa fa-sign-in"></span>
+          </button>
+        </div>
+        <div class="btn-group">
+          <button id="signOutButton" title="Sign Out" style="display:none">
+            <span class="fa fa-sign-out"></span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div id="appContent">
+      <div id="toolbarArea">
+        <div id="mainToolbar">
+          <div class="btn-toolbar pull-left">
+            <div class="btn-group">
+              <button type="button" class="btn" data-toggle="dropdown" title="File commands">
+                <span class="fa fa-book"></span> File <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li id="saveButton"><a href="#">Save</a></li>
+                <li id="renameButton"><a href="#">Rename</a></li>
+                <li class="divider"></li>
+                <li id="downloadButton"><a href="#">Download</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="contentArea">
+        <div id="mainArea">
+          <div id="mainContent" class="container fileMainContent">
+            <div id="ipython-main-app" style="padding:0px">
+              <div id="site">
+                <div id="texteditor-backdrop">
+                  <div id="texteditor-container" style="height:100%;width:100%"></div>
+                  <div id='tooltip' class='ipython_tooltip' style='display:none'></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="/static/components/es6-promise/promise.min.js"></script>
+  <script src="/static/components/requirejs/require.js"></script>
+  <script>
+    require.config({
+      baseUrl: '/static/',
+      shim: {
+        jqueryui: {
+          deps: ["jquery"],
+          exports: "$"
+        }
+      }
+    });
+    require.config({
+       map: {
+         '*': {
+           'contents': 'services/contents',
+         }
+       }
+    });
+    window.datalab = {};
+  </script>
+  <script src="/static/edit/js/main.min.js" charset="utf-8"></script>
+  <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
+</body>
+</html>


### PR DESCRIPTION
We previously were serving the file editing page using the
built-in Jupyter UI. That meant that it looked wildly different
from the rest of Datalab, and was missing the Datalab-specific
UI elements like the sign-in and feedback buttons.

This version of the editor page is functional, but not yet
feature complete. The remaining missing features will be added
in later commits.