### PR TITLE
Fix a bug in the template serving.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -315,7 +315,7 @@ function responseHandler(proxyResponse: http.ClientResponse,
       templateData['notebookPath'] = path.substr(11);
       templateData['notebookName'] = path.substr(path.lastIndexOf('/') + 1);
 
-      page = 'notebook';
+      page = 'nb';
     }
     sendTemplate(page, templateData, response);
 


### PR DESCRIPTION
PR #880 introduced a bug in the template rendering for the notebook
UI where the name of the template was wrong (`notebook` instead of
`nb`).

This change fixes that.