### PR TITLE
Add support for connecting to a kernel gateway.

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -137,6 +137,14 @@ RUN ipython profile create default && \
     cd /datalab/web && /tools/node/bin/npm install && \
     cd /
 
+RUN wget https://github.com/jupyter/kernel_gateway_demos/archive/e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip && \
+    unzip -qq e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip -d kernel_gateway_demos && \
+    rm e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip && \
+    cd ./kernel_gateway_demos/kernel_gateway_demos-e653b2bd3ca91ef1af2a13c397766484dcb7b76d && \
+    pip install ./nb2kg/
+
+ENV EXPERIMENTAL_KERNEL_GATEWAY_URL=""
+
 # Include this line above to enable ipywidgets. These aren't working 100% yet so 
 # we don't enable them.
 #    jupyter nbextension enable --py widgetsnbextension && \

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -37,5 +37,11 @@ then
   . ~/startup.sh
 fi
 
+# Install the kernel gateway server extension, if a kernel gateway URL has been specified
+if [ -n "${KG_URL}" ]
+then
+    jupyter serverextension enable --py nb2kg --sys-prefix
+fi
+
 # Start the DataLab server
 forever /datalab/web/app.js

--- a/containers/datalab/content/setup-env.sh
+++ b/containers/datalab/content/setup-env.sh
@@ -25,3 +25,7 @@ then
   export CLOUDSDK_CONFIG=/content/datalab/.config
 fi
 
+if [ -n "${EXPERIMENTAL_KERNEL_GATEWAY_URL}" ]
+then
+  export KG_URL="${EXPERIMENTAL_KERNEL_GATEWAY_URL}"
+fi

--- a/containers/datalab/run-extended.sh
+++ b/containers/datalab/run-extended.sh
@@ -84,4 +84,5 @@ docker run -it --entrypoint=$ENTRYPOINT \
   -v "$CONTENT:/content" \
   -e "PROJECT_ID=$PROJECT_ID" \
   -e "DATALAB_ENV=local" \
+  -e "EXPERIMENTAL_KERNEL_GATEWAY_URL=${EXPERIMENTAL_KERNEL_GATEWAY_URL}" \
   $DOCKERIMAGE

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -49,4 +49,5 @@ docker run -it --entrypoint=$ENTRYPOINT \
   -v "$CONTENT:/content" \
   -e "PROJECT_ID=$PROJECT_ID" \
   -e "DATALAB_ENV=local" \
+  -e "EXPERIMENTAL_KERNEL_GATEWAY_URL=${EXPERIMENTAL_KERNEL_GATEWAY_URL}" \
   datalab

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -107,9 +107,20 @@ function createJupyterServer(userId: string): JupyterServer {
     '--notebook-dir="' + server.notebooks + '"'
   ]);
 
+  var notebookEnv: any = process.env;
+  if ('KG_URL' in notebookEnv && notebookEnv['KG_URL']) {
+    logging.getLogger().info(
+      'Found a kernel gateway URL of %s... configuring the notebook to use it', notebookEnv['KG_URL']);
+    processArgs = processArgs.concat([
+      '--NotebookApp.session_manager_class=nb2kg.managers.SessionManager',
+      '--NotebookApp.kernel_manager_class=nb2kg.managers.RemoteKernelManager',
+      '--NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager'
+    ]);
+  }
+
   var processOptions = {
     detached: false,
-    env: process.env
+    env: notebookEnv
   };
 
   server.childProcess = childProcess.spawn('jupyter', processArgs, processOptions);


### PR DESCRIPTION
This change allows Datalab to use a [kernel gateway](https://github.com/jupyter/kernel_gateway) for running the notebook kernels.

The setting for whether or not to use a gateway is based on the `KG_URL` environment variable, which defines the URL of the gateway (if any) to use.

If that environment variable is set, then *all* kernels are run using that gateway. Otherwise, all kernels are run locally within the Datalab container.

For example:

    KG_URL=http://localhost:8080 ./containers/datalab/run.sh

will run Datalab with all kernels being run by a kernel gateway running on localhost:8080.

... whereas:

    ./containers/datalab/run.sh

will run Datalab will all kernels running inside of the Datalab container.

Note: This uses the [nb2kg server extension](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg), which is demo code. As such, we require that the user explicitly opt-in to using it.