### PR TITLE
Fix a bug in the port selection for the nested Jupyter servers.

### DIFF
--- a/externs/ts/node/tcp-port-used.d.ts
+++ b/externs/ts/node/tcp-port-used.d.ts
@@ -18,5 +18,7 @@ declare module 'tcp-port-used' {
     then(resolved: () => void, rejected: (error: Error) => void): void;
   }
 
-  export function waitUntilUsed(port: number): SimplePromise;
+  export function waitUntilFree(port: number): SimplePromise;
+
+  export function waitUntilUsed(port: number, retryMs: number, timeOutMs: number): SimplePromise;
 }

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -36,6 +36,8 @@ interface JupyterServer {
   notebooks: string;
   childProcess?: childProcess.ChildProcess;
   proxy?: httpProxy.ProxyServer;
+
+  portResolved: ()=>void;
 }
 
 /**
@@ -65,6 +67,7 @@ var appSettings: common.Settings;
 
 function pipeOutput(stream: NodeJS.ReadableStream, port: number, error: boolean) {
   stream.setEncoding('utf8');
+
   stream.on('data', (data: string) => {
     // Jupyter generates a polling kernel message once every 3 seconds
     // per kernel! This adds too much noise into the log, so avoid
@@ -80,56 +83,80 @@ function pipeOutput(stream: NodeJS.ReadableStream, port: number, error: boolean)
  * Starts the Jupyter server, and then creates a proxy object enabling
  * routing HTTP and WebSocket requests to Jupyter.
  */
-function createJupyterServer(userId: string): JupyterServer {
+function createJupyterServer(userId: string, remainingAttempts: number) {
   var port = nextJupyterPort;
   nextJupyterPort++;
 
-  var userDir = userManager.getUserDir(userId);
-  if (!fs.existsSync(userDir)) {
-    fs.mkdirSync(userDir, parseInt('0755',8));
-  }
+  tcp.waitUntilFree(port).then(
+    function() {
+      var userDir = userManager.getUserDir(userId);
+      if (!fs.existsSync(userDir)) {
+        fs.mkdirSync(userDir, parseInt('0755',8));
+      }
 
-  var server: JupyterServer = {
-    userId: userId,
-    port: port,
-    notebooks: userDir
-  };
+      var server: JupyterServer = {
+        userId: userId,
+        port: port,
+        notebooks: userDir,
+        portResolved: function() {},
+      };
 
-  function exitHandler(code: number, signal: string): void {
-    logging.getLogger().error('Jupyter process %d for user %s exited due to signal: %s',
-                              server.childProcess.pid, userId, signal);
-    delete jupyterServers[server.userId];
-  }
+      function exitHandler(code: number, signal: string): void {
+        logging.getLogger().error('Jupyter process %d for user %s exited due to signal: %s',
+                                  server.childProcess.pid, userId, signal);
+        delete jupyterServers[server.userId];
+      }
 
-  var processArgs = appSettings.jupyterArgs.slice().concat([
-    '--port=' + server.port,
-    '--notebook-dir="' + server.notebooks + '"'
-  ]);
+      var processArgs = appSettings.jupyterArgs.slice().concat([
+        '--port=' + server.port,
+        '--port-retries=0',
+        '--notebook-dir="' + server.notebooks + '"'
+      ]);
 
-  var processOptions = {
-    detached: false,
-    env: process.env
-  };
+      var processOptions = {
+        detached: false,
+        env: process.env
+      };
 
-  server.childProcess = childProcess.spawn('jupyter', processArgs, processOptions);
-  server.childProcess.on('exit', exitHandler);
-  logging.getLogger().info('Jupyter process for user %s started with pid %d and args %j',
-                           userId, server.childProcess.pid, processArgs);
+      server.childProcess = childProcess.spawn('jupyter', processArgs, processOptions);
+      server.childProcess.on('exit', exitHandler);
+      logging.getLogger().info('Jupyter process for user %s started with pid %d and args %j',
+                               userId, server.childProcess.pid, processArgs);
 
-  // Capture the output, so it can be piped for logging.
-  pipeOutput(server.childProcess.stdout, server.port, /* error */ false);
-  pipeOutput(server.childProcess.stderr, server.port, /* error */ true);
+      // Capture the output, so it can be piped for logging.
+      pipeOutput(server.childProcess.stdout, server.port, /* error */ false);
+      pipeOutput(server.childProcess.stderr, server.port, /* error */ true);
 
-  // Then create the proxy.
-  var proxyOptions: httpProxy.ProxyServerOptions = {
-    target: 'http://127.0.0.1:' + server.port
-  };
+      // Create the proxy.
+      var proxyOptions: httpProxy.ProxyServerOptions = {
+        target: 'http://127.0.0.1:' + port
+      };
 
-  server.proxy = httpProxy.createProxyServer(proxyOptions);
-  server.proxy.on('proxyRes', responseHandler);
-  server.proxy.on('error', errorHandler);
+      server.proxy = httpProxy.createProxyServer(proxyOptions);
+      server.proxy.on('proxyRes', responseHandler);
+      server.proxy.on('error', errorHandler);
 
-  return server;
+      tcp.waitUntilUsed(server.port, 100, 3000).then(
+        function() {
+          jupyterServers[userId] = server;
+          logging.getLogger().info('Jupyter server started for %s.', userId);
+          callbackManager.invokeAllCallbacks(userId, null);
+        },
+        function(e) {
+          logging.getLogger().error(e, 'Failed to start Jupyter server for user %s.', userId);
+          callbackManager.invokeAllCallbacks(userId, e);
+        });
+    },
+    function(e) {
+      logging.getLogger().error(e, 'Failed to find a free port at %d', port);
+      if (remainingAttempts > 0) {
+        attemptStartForUser(userId, remainingAttempts - 1);
+      }
+      else {
+        logging.getLogger().error('Failed to start Jupyter server for user %s.', userId);
+        callbackManager.invokeAllCallbacks(userId, new Error('failed to start jupyter server.'));
+      }
+    });
 }
 
 export function getPort(request: http.ServerRequest): number {
@@ -156,6 +183,16 @@ export function getInfo(): Array<common.Map<any>> {
   return info;
 }
 
+function attemptStartForUser(userId: string, remainingAttempts: number) {
+  try {
+    createJupyterServer(userId, remainingAttempts);
+  }
+  catch (e) {
+    logging.getLogger().error(e, 'Failed to start Jupyter server for user %s.', userId);
+    callbackManager.invokeAllCallbacks(userId, e);
+  }
+}
+
 /**
  * Starts a jupyter server instance for given user.
  */
@@ -172,31 +209,8 @@ export function startForUser(userId: string, cb: common.Callback0) {
     return;
   }
 
-  try {
-    logging.getLogger().info('Starting jupyter server for %s.', userId);
-    server = createJupyterServer(userId);
-    if (server) {
-      tcp.waitUntilUsed(server.port).then(
-        function() {
-          jupyterServers[userId] = server;
-          logging.getLogger().info('Jupyter server started for %s.', userId);
-          callbackManager.invokeAllCallbacks(userId, null);
-        },
-        function(e) {
-          logging.getLogger().error(e, 'Failed to start Jupyter server for user %s.', userId);
-          callbackManager.invokeAllCallbacks(userId, e);
-        });
-    }
-    else {
-      // Should never be here.
-      logging.getLogger().error('Failed to start Jupyter server for user %s.', userId);
-      callbackManager.invokeAllCallbacks(userId, new Error('failed to start jupyter server.'));
-    }
-  }
-  catch (e) {
-    logging.getLogger().error(e, 'Failed to start Jupyter server for user %s.', userId);
-    callbackManager.invokeAllCallbacks(userId, e);
-  }
+  logging.getLogger().info('Starting jupyter server for %s.', userId);
+  attemptStartForUser(userId, 10);
 }
 
 /**


### PR DESCRIPTION
Previously, Datalab was picking the next port that it wanted Jupyter
to run on, passing that to the launched Jupyter process using the
'--port' flag, and then assuming that the server did in fact start
listening on that port.

However, if the port selected was already in use, then Jupyter would
automatically try the next port in sequence. That could cause an issue
where the one Jupyter server (for one user) was listening on a port
that we thought was being used by the Jupyter server for a different
user.

This change fixes that bug by doing the following:

1. Verifying that the next port is free before we try to start a
   Jupyter server listening on it.
2. Telling the Jupyter server to not try any additional ports if
   the one specified was not available (so it will instead die in
   that situation).

The combination of these two steps effectively moves the retry
logic for picking a port out of the Jupyter process and in to the
wrapping Node server.

There are still two failure cases that can manifest even with this
change.

The first is that if the attempt to start a Jupyter server
fails more than 10 times, then the retry logic will give up and
an internal error will be reported to the user. This failure mode
always existed, but now we will be properly tracking it.

The second is a race condition where another process grabs the
requested port between the time when we verify that it is free
and the time that the launched Jupyter server starts up. If that
happens, then the Jupyter server will kill itself, and it will
be removed from the users->Jupyter servers map. However, the
request that caused us to spin up a Jupyter server to begin
with will be forwarded to the process that took hold of the
assigned port.

This failure case should be difficult enough to trigger that it
will not occur in practice.

We believe this will fix the issue reported in #884 