### PR TITLE
Change the logic for picking the next Jupyter port more intelligent.

### DIFF
--- a/externs/ts/node/tcp-port-used.d.ts
+++ b/externs/ts/node/tcp-port-used.d.ts
@@ -18,7 +18,11 @@ declare module 'tcp-port-used' {
     then(resolved: () => void, rejected: (error: Error) => void): void;
   }
 
-  export function waitUntilFree(port: number): SimplePromise;
+  class BooleanPromise {
+    then(resolved: (b: boolean) => void, rejected: (error: Error) => void): void;
+  }
+
+  export function check(port: number, host: any): BooleanPromise;
 
   export function waitUntilUsed(port: number, retryMs: number, timeOutMs: number): SimplePromise;
 }


### PR DESCRIPTION
Previously, the logic was just to increment the next port number,
and then try to launch a Jupyter server on that port if it was
free. If that failed at any step, then we would retry, but with
a counter for the max number of retries decremented.

This meant that the next port already being in use counted against
the retry count, and that should not be the case.

With this change, the search for a free port will not count against
the the retry count.

This fixes #891