### PR TITLE
Fix erroneous duplicated quotes in the HTML templates.

### DIFF
--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -58,7 +58,7 @@
           </button>
         </div>
         <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton" class="btn"">
+          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton" class="btn">
             <button id="docsButton" title="Samples and Tutorials">
               <span class="fa fa-book"></span>
             </button>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -36,7 +36,7 @@
           </button>
         </div>
         <div class="btn-group">
-          <a href="/tree/datalab/docs" class="btn"">
+          <a href="/tree/datalab/docs" class="btn">
             <button title="Samples and Tutorials">
               <span class="fa fa-book"></span>
             </button>
@@ -65,7 +65,7 @@
               <button id="sessionsButton" type="button" class="btn" title="View Active Notebook Sessions">
                 <span class="fa fa-tasks"></span> Sessions
               </button>
-              <a href="/tree/datalab/docs/notebooks" class="btn"">
+              <a href="/tree/datalab/docs/notebooks" class="btn">
                 <button type="button" class="btn" title="View Tutorials and Sample Notebooks">
                   <span class="fa fa-book"></span> Docs
                 </button>


### PR DESCRIPTION
Both the notebook and tree-view HTML templates have
some attribute values specified with too many closing
quotes (e.g. `class="btn""`).

This does not seem to have affected the rendering of those
pages, but it was confusing the syntax-highlighting features
of some editors when displaying the HTML source.

This change fixes that by removing the duplicated closing quotes.