### PR TITLE
Split the `sessions` UI out into its own page.

### DIFF
--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -126,7 +126,8 @@ function handleRequest(request: http.ServerRequest,
       (path.indexOf('/nbconvert') == 0) ||
       (path.indexOf('/nbextensions') == 0) ||
       (path.indexOf('/files') == 0) ||
-      (path.indexOf('/edit') == 0)) {
+      (path.indexOf('/edit') == 0) ||
+      (path.indexOf('/sessions') == 0)) {
     handleJupyterRequest(request, response);
     return;
   }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -177,7 +177,7 @@ body {
 .treeMainContent {
   overflow: auto;
   position: absolute;
-  top: 48px;
+  top: 0px;
   left: 0px;
   right: 0px;
   bottom: 0px;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -747,18 +747,6 @@ function initializeEditApplication(ipy, editor) {
 
 
 function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, utils) {
-  function showContent(e) {
-    document.getElementById('notebooks').classList.add('active');
-    document.getElementById('running').classList.remove('active');
-    e.target.blur();
-  }
-
-  function showSessions(e) {
-    document.getElementById('notebooks').classList.remove('active');
-    document.getElementById('running').classList.add('active');
-    e.target.blur();
-  }
-
   function addNotebook(e) {
     newNotebook.new_notebook();
     e.target.blur();
@@ -783,9 +771,6 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
       });
     e.target.blur();
   }
-
-  document.getElementById('contentButton').addEventListener('click', showContent, false);
-  document.getElementById('sessionsButton').addEventListener('click', showSessions, false);
 
   document.getElementById('addNotebookButton').addEventListener('click', addNotebook, false);
   document.getElementById('addFolderButton').addEventListener('click', addFolder, false);
@@ -859,7 +844,6 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
   }
 
   checkVersion(window.datalab.versions);
-
 }
 
 

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -49,6 +49,13 @@
           </a>
         </div>
         <div class="btn-group">
+          <a href="/sessions" target="_blank" id="sessionsButton" class="btn">
+            <button title="Running Sessions">
+              <span class="fa fa-tasks"></span>
+            </button>
+          </a>
+        </div>
+        <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none">
             <span class="fa fa-sign-in"></span>
           </button>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -65,6 +65,13 @@
           </a>
         </div>
         <div class="btn-group">
+          <a href="/sessions" target="_blank" id="sessionsButton" class="btn">
+            <button title="Running Sessions">
+              <span class="fa fa-tasks"></span>
+            </button>
+          </a>
+        </div>
+        <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none">
             <span class="fa fa-sign-in"></span>
           </button>

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -10,9 +10,8 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
-<body class="notebook_list"
+<body class="session_list"
   data-base-url="<%baseUrl%>"
-  data-notebook-path="<%notebookPath%>"
   data-terminals-available="False"
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
@@ -36,7 +35,7 @@
           </button>
         </div>
         <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks" class="btn">
+          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton" class="btn">
             <button title="Samples and Tutorials">
               <span class="fa fa-book"></span>
             </button>
@@ -65,51 +64,17 @@
       <div id="mainArea">
         <div id="mainContent" class="container treeMainContent">
           <div id="ipython-main-app">
-            <div id="updateMessageArea">
-            </div>
             <div id="tab_content" class="tabbable">
               <div class="tab-content">
-                <div id="notebooks" class="tab-pane active">
-                  <div id="notebook_toolbar" class="row">
-                    <form id="alternate_upload"  class="alternate_upload">
-                      <div class="btn-toolbar pull-left">
-                        <div class="btn-group">
-                          <button id="addNotebookButton" type="button" class="btn" title="Add a new notebook">
-                            <span class="fa fa-plus-square"></span> Notebook
-                          </button>
-                          <button id="addFolderButton" type="button" class="btn" title="Add a new folder">
-                            <span class="fa fa-plus-square"></span> Folder
-                          </button>
-                          <span id="uploadButton" type="button" class="btn" title="Upload notebook(s)">
-                            <span class="fa fa-upload"></span>
-                            <input type="file" name="datafile" class="fileinput" multiple="multiple" value="Upload" />
-                            Upload
-                          </span>
-                          <button id="duplicateButton" type="button" class="btn duplicate-button" title="Create a copy of the selected item(s)">
-                            <span class="fa fa-files-o"></span> Copy
-                          </button>
-                          <button id="renameButton" type="button" class="btn rename-button" title="Rename selected item(s)">
-                            <span class="fa fa-edit"></span> Rename
-                          </button>
-                          <button id="deleteButton" type="button" class="btn delete-button" title="Deleted selected item(s)">
-                            <span class="fa fa-trash-o"></span> Delete
-                          </button>
-                        </div>
+                <div id="running" class="tab-pane active">
+                  <div id="running_list">
+                    <div id="running_list_header" class="row list_header">
+                      <div>
+                        Active Notebooks
                       </div>
-                    </form>
-                  </div>
-                  <div id="notebook_list">
-                    <div id="notebook_list_header" class="row list_header">
-                      <div class="btn-group dropdown" id="tree-selector">
-                        <button title="Select All / None" type="button" class="btn btn-default btn-xs" id="button-select-all">
-                          <input type="checkbox" class="pull-left tree-selector" id="select-all"></input>
-                        </button>
-                      </div>
-                      <div id="project_name">
-                        <ul class="breadcrumb">
-                          <li><a href="/tree"><i class="fa fa-home"></i></a></li>
-                        </ul>
-                      </div>
+                    </div>
+                    <div id="running_list_placeholder" class="row list_placeholder">
+                      <div> There are no running sessions. </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Previously, the `tree` UI included two unrelated views; a directory
view of the file system, and a list view of running sessions.

This was confusing as it was not intuitive that you should open
the file listing in order to be able to switch to the session
list, nor was it obvious that the UI controls on that page
toggled the type of view that was presented.

This change tries to clean all of that up by splitting the
session listing into its own page, and putting a link to that
page in the button toolbar that is in the top, right-hand
corner of the UI.