### PR TITLE
Update the reference to the datalab python libraries.

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -134,8 +134,8 @@ RUN ipython profile create default && \
     jupyter notebook --generate-config && \
     mkdir -p /datalab/lib && \
     cd /datalab/lib && \
-    git clone https://github.com/googledatalab/datalab.git && \
-    cd /datalab/lib/datalab && \
+    git clone https://github.com/googledatalab/pydatalab.git && \
+    cd /datalab/lib/pydatalab && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
     pip install . && \
     jupyter nbextension install --py datalab.notebook && \


### PR DESCRIPTION
The repository 'googledatalab/datalab' is being renamed as
'googledatalab/pydatalab' so that this repository can be
migrated to the 'googledatalab' organization.

This change is necessary for the building of the Docker image
to pick up the library from its new location.